### PR TITLE
Handle custom DB paths as SQLite URIs

### DIFF
--- a/src/ispec/db/connect.py
+++ b/src/ispec/db/connect.py
@@ -35,9 +35,11 @@ def get_db_path(file=None) -> Path:
     if file is None:
         db_path = get_db_dir()
         db_file = db_path / "ispec.db"
-        db_file = "sqlite:///" + str(db_file)
-    logger.info("setting db_path to %s", str(db_file))
-    return db_file
+    else:
+        db_file = Path(file)
+    db_uri = "sqlite:///" + str(db_file)
+    logger.info("setting db_path to %s", db_uri)
+    return db_uri
 
 
 @lru_cache(maxsize=None)

--- a/tests/unit/db/test_connect.py
+++ b/tests/unit/db/test_connect.py
@@ -1,0 +1,21 @@
+from ispec.db import connect
+
+
+def _clear_caches():
+    connect.get_db_path.cache_clear()
+    connect.get_db_dir.cache_clear()
+
+
+def test_get_db_path_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("ISPEC_DB_DIR", str(tmp_path))
+    _clear_caches()
+    expected = "sqlite:///" + str(tmp_path / "ispec.db")
+    assert connect.get_db_path() == expected
+
+
+def test_get_db_path_custom(tmp_path):
+    _clear_caches()
+    custom = tmp_path / "custom.db"
+    expected = "sqlite:///" + str(custom)
+    assert connect.get_db_path(custom) == expected
+


### PR DESCRIPTION
## Summary
- convert custom `file` argument to SQLite URI in `get_db_path`
- log the chosen database URI
- add tests for default and custom database paths

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_connection')*
- `pytest tests/unit/db/test_connect.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5cbedf960833296513ba439d006e1