### PR TITLE
Add skeleton AI module with chat and tensor utilities

### DIFF
--- a/src/ispec/ai/__init__.py
+++ b/src/ispec/ai/__init__.py
@@ -1,0 +1,23 @@
+"""AI helpers for interacting with LLMs and tensor utilities.
+
+This package provides skeleton implementations for chat sessions
+that may later be wired to a large language model as well as simple
+numerical helpers that operate on Python lists as lightweight tensors.
+"""
+
+from .chat import ChatMessage, ChatSession
+from .llm import generate_response, handle_user_message
+from .tensor_ops import matmul, transpose
+from .task_queue import TaskQueue
+from .worker import ChatWorker
+
+__all__ = [
+    "ChatMessage",
+    "ChatSession",
+    "ChatWorker",
+    "TaskQueue",
+    "generate_response",
+    "handle_user_message",
+    "matmul",
+    "transpose",
+]

--- a/src/ispec/ai/api.py
+++ b/src/ispec/ai/api.py
@@ -1,0 +1,13 @@
+"""Helpers for talking to the backend API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import requests
+
+
+def put_response(url: str, data: Dict[str, Any]) -> None:
+    """Send ``data`` to ``url`` using an HTTP PUT request."""
+
+    requests.put(url, json=data, timeout=5)

--- a/src/ispec/ai/chat.py
+++ b/src/ispec/ai/chat.py
@@ -1,0 +1,47 @@
+"""Chat session data structures used by the AI module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """A single message in a chat conversation."""
+
+    sender: str
+    content: str
+
+
+@dataclass(frozen=True)
+class ChatSession:
+    """Immutable chat session holding the conversation history.
+
+    The session stores messages as a tuple so that modifications return
+    a new :class:`ChatSession` instance, keeping the dataclass frozen and
+    side-effect free.
+    """
+
+    messages: Tuple[ChatMessage, ...] = ()
+
+    def add_message(self, sender: str, content: str) -> "ChatSession":
+        """Return a new session with an additional message."""
+
+        return ChatSession(self.messages + (ChatMessage(sender, content),))
+
+    def add_user_message(self, content: str) -> "ChatSession":
+        """Convenience wrapper to add a user message."""
+
+        return self.add_message("user", content)
+
+    def add_ai_message(self, content: str) -> "ChatSession":
+        """Convenience wrapper to add an AI generated message."""
+
+        return self.add_message("ai", content)
+
+    @classmethod
+    def from_messages(cls, messages: Iterable[ChatMessage]) -> "ChatSession":
+        """Create a session from an iterable of messages."""
+
+        return cls(tuple(messages))

--- a/src/ispec/ai/llm.py
+++ b/src/ispec/ai/llm.py
@@ -1,0 +1,41 @@
+"""Placeholder utilities for interacting with a language model."""
+
+from __future__ import annotations
+
+from .chat import ChatSession
+
+
+def generate_response(session: ChatSession) -> ChatSession:
+    """Generate a response to the latest user message.
+
+    This is a very small stub that simply echoes the last user message.
+    In a real implementation this function would call out to an LLM such
+    as one served by `ollama` or any other provider.
+    """
+
+    for message in reversed(session.messages):
+        if message.sender == "user":
+            content = f"Echo: {message.content}"
+            return session.add_ai_message(content)
+    raise ValueError("No user message found to respond to")
+
+
+def handle_user_message(content: str, *, session: ChatSession | None = None) -> ChatSession:
+    """Add a user message and generate a response.
+
+    Parameters
+    ----------
+    content:
+        The user's input.
+    session:
+        Existing session to append to. If ``None`` a new session is created.
+
+    Returns
+    -------
+    ChatSession
+        A new session including the user message and the generated reply.
+    """
+
+    session = session or ChatSession()
+    session = session.add_user_message(content)
+    return generate_response(session)

--- a/src/ispec/ai/task_queue.py
+++ b/src/ispec/ai/task_queue.py
@@ -1,0 +1,69 @@
+"""Thread-based task queue for processing work items sequentially."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from queue import Queue, Empty
+from threading import Event, Thread
+from typing import Any, Callable, Dict, Tuple
+
+
+@dataclass
+class Task:
+    """Represent a unit of work to be executed."""
+
+    func: Callable[..., Any]
+    args: Tuple[Any, ...] = ()
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def run(self) -> None:
+        self.func(*self.args, **self.kwargs)
+
+
+class TaskQueue:
+    """Simple task queue running in a dedicated thread.
+
+    The queue uses a background thread to execute submitted tasks one after
+    the other. It can be started and stopped to control processing.
+    """
+
+    def __init__(self) -> None:
+        self._queue: Queue[Task | None] = Queue()
+        self._stop_event = Event()
+        self._thread = Thread(target=self._worker, daemon=True)
+
+    def start(self) -> None:
+        """Start the worker thread if not already running."""
+
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the worker thread to exit and wait for it."""
+
+        self._stop_event.set()
+        self._queue.put(None)
+        self._thread.join()
+
+    def add_task(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Submit a callable to be executed by the queue."""
+
+        self._queue.put(Task(func, args, kwargs))
+
+    def join(self) -> None:
+        """Block until all tasks have been processed."""
+
+        self._queue.join()
+
+    def _worker(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                task = self._queue.get(timeout=0.1)
+            except Empty:
+                continue
+            if task is None:
+                break
+            try:
+                task.run()
+            finally:
+                self._queue.task_done()

--- a/src/ispec/ai/tensor_ops.py
+++ b/src/ispec/ai/tensor_ops.py
@@ -1,0 +1,40 @@
+"""Minimal tensor utilities using only Python built-ins."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, List
+
+Matrix = Sequence[Sequence[float]]
+
+
+def transpose(matrix: Matrix) -> List[List[float]]:
+    """Return the transpose of ``matrix``.
+
+    Parameters
+    ----------
+    matrix:
+        Matrix represented as a sequence of sequences.
+    """
+
+    return [list(row) for row in zip(*matrix)]
+
+
+def matmul(a: Matrix, b: Matrix) -> List[List[float]]:
+    """Multiply two matrices ``a`` and ``b``.
+
+    The implementation operates purely on Python lists so it can be used
+    without additional numerical dependencies.
+    """
+
+    if not a or not b:
+        raise ValueError("Input matrices must be non-empty")
+    if len(a[0]) != len(b):
+        raise ValueError("Incompatible shapes for matrix multiplication")
+
+    result: List[List[float]] = []
+    for row in a:
+        new_row = []
+        for col in zip(*b):
+            new_row.append(sum(x * y for x, y in zip(row, col)))
+        result.append(new_row)
+    return result

--- a/src/ispec/ai/worker.py
+++ b/src/ispec/ai/worker.py
@@ -1,0 +1,38 @@
+"""Background worker integrating chat sessions, task queue and backend API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .api import put_response
+from .chat import ChatSession
+from .llm import generate_response
+from .task_queue import TaskQueue
+
+
+@dataclass
+class ChatWorker:
+    """Process user messages using a background task queue."""
+
+    backend_url: Optional[str] = None
+    session: ChatSession = field(default_factory=ChatSession)
+    queue: TaskQueue = field(default_factory=TaskQueue)
+
+    def start(self) -> None:
+        self.queue.start()
+
+    def stop(self) -> None:
+        self.queue.stop()
+
+    def enqueue(self, content: str) -> None:
+        """Queue a user message for processing."""
+
+        self.queue.add_task(self._process_message, content)
+
+    # internal --------------------------------------------------------------
+    def _process_message(self, content: str) -> None:
+        self.session = self.session.add_user_message(content)
+        self.session = generate_response(self.session)
+        if self.backend_url:
+            put_response(self.backend_url, {"response": self.session.messages[-1].content})

--- a/tests/unit/ai/test_chat.py
+++ b/tests/unit/ai/test_chat.py
@@ -1,0 +1,20 @@
+"""Tests for chat session utilities."""
+
+from ispec.ai import ChatSession, handle_user_message
+
+
+def test_chat_session_add_message():
+    session = ChatSession()
+    session2 = session.add_user_message("hello")
+    assert session is not session2
+    assert len(session.messages) == 0
+    assert len(session2.messages) == 1
+    assert session2.messages[0].content == "hello"
+
+
+def test_handle_user_message_generates_response():
+    session = handle_user_message("hi there")
+    assert len(session.messages) == 2
+    assert session.messages[0].sender == "user"
+    assert session.messages[1].sender == "ai"
+    assert "hi there" in session.messages[1].content

--- a/tests/unit/ai/test_task_queue.py
+++ b/tests/unit/ai/test_task_queue.py
@@ -1,0 +1,14 @@
+"""Tests for the threaded task queue."""
+
+from ispec.ai.task_queue import TaskQueue
+
+
+def test_task_queue_executes_tasks():
+    queue = TaskQueue()
+    queue.start()
+    results = []
+    queue.add_task(results.append, 1)
+    queue.add_task(results.append, 2)
+    queue.join()
+    queue.stop()
+    assert results == [1, 2]

--- a/tests/unit/ai/test_tensor_ops.py
+++ b/tests/unit/ai/test_tensor_ops.py
@@ -1,0 +1,14 @@
+"""Tests for simple tensor operations."""
+
+from ispec.ai import matmul, transpose
+
+
+def test_transpose():
+    matrix = [[1, 2, 3], [4, 5, 6]]
+    assert transpose(matrix) == [[1, 4], [2, 5], [3, 6]]
+
+
+def test_matmul():
+    a = [[1, 2], [3, 4]]
+    b = [[5, 6], [7, 8]]
+    assert matmul(a, b) == [[19, 22], [43, 50]]

--- a/tests/unit/ai/test_worker.py
+++ b/tests/unit/ai/test_worker.py
@@ -1,0 +1,22 @@
+"""Tests for the chat worker and backend integration."""
+
+import ispec.ai.worker as worker_module
+from ispec.ai import ChatWorker
+
+
+def test_chat_worker_sends_backend(monkeypatch):
+    sent = []
+
+    def fake_put(url, data):
+        sent.append((url, data))
+
+    monkeypatch.setattr(worker_module, "put_response", fake_put)
+    worker = ChatWorker(backend_url="http://example.com/api")
+    worker.start()
+    worker.enqueue("hi")
+    worker.queue.join()
+    worker.stop()
+
+    assert sent and sent[0][0] == "http://example.com/api"
+    # ensure AI message generated
+    assert worker.session.messages[-1].sender == "ai"


### PR DESCRIPTION
## Summary
- expose TaskQueue and ChatWorker in `ispec.ai`
- add threaded task queue and backend worker for processing chat messages
- include HTTP PUT helper and tests for background processing

## Testing
- `pytest tests/unit/ai/test_chat.py tests/unit/ai/test_tensor_ops.py tests/unit/ai/test_task_queue.py tests/unit/ai/test_worker.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c5d9ec55d483328b4fe426ee70de67