### PR TITLE
Graceful fallback for missing sentence transformer

### DIFF
--- a/tests/unit/io/test_column_matching.py
+++ b/tests/unit/io/test_column_matching.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from ispec.io import column_matching
+
+
+def test_match_columns_without_transformer(monkeypatch):
+    # Simulate environment without sentence_transformers
+    monkeypatch.setattr(column_matching, "_default_model", None)
+
+    def fail(*args, **kwargs):
+        raise AssertionError("score_matches should not be called when transformer is unavailable")
+
+    monkeypatch.setattr(column_matching, "score_matches", fail)
+
+    res = column_matching.match_columns(["foo"], ["foo", "bar"])
+    assert res == {"foo": "foo"}
+
+
+def test_match_columns_with_transformer(monkeypatch):
+    # Simulate presence of transformer by providing a dummy model and scoring function
+    called = {"flag": False}
+
+    def fake_score(src_cols, tgt_cols, model=None):
+        called["flag"] = True
+        return np.array([[0.9]])
+
+    monkeypatch.setattr(column_matching, "score_matches", fake_score)
+    monkeypatch.setattr(column_matching, "_default_model", object())
+
+    res = column_matching.match_columns(["foo"], ["foo"])
+    assert res == {"foo": "foo"}
+    assert called["flag"]


### PR DESCRIPTION
## Summary
- avoid hard dependency on `sentence_transformers` by catching `ImportError`
- ensure column matching works with or without transformer and add tests

## Testing
- `PYTHONPATH=src pytest tests/unit/io/test_column_matching.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ecaa34e48332bb0e367d9d8444e9