### PR TITLE
Simplify CLI dispatch and expand tests

### DIFF
--- a/src/ispec/cli/api.py
+++ b/src/ispec/cli/api.py
@@ -3,28 +3,37 @@ from ispec.logging import get_logger
 
 
 def register_subcommands(subparsers):
-
-    status_parser_ = subparsers.add_parser("status", help="Check api status")
+    subparsers.add_parser("status", help="Check api status")
     starter_parser = subparsers.add_parser("start", help="start the API server")
-    starter_parser.add_argument(
-        "--host", default="localhost", help="Host to run the API server "
-    )
-    starter_parser.add_argument(
-        "--port", type=int, default=8000, help="Port to run the API server on"
-    )
+    starter_parser.add_argument("--host", default="localhost", help="Host to run the API server ")
+    starter_parser.add_argument("--port", type=int, default=8000, help="Port to run the API server on")
 
 
 def dispatch(args):
+    """Dispatch API CLI subcommands using a simple lookup table.
 
+    Errors from handlers are allowed to propagate so callers can see the
+    underlying exception. Unknown subcommands raise ``ValueError`` with a clear
+    message.
+    """
     logger = get_logger(__file__)
 
-    from ispec.api.main import app
-    import uvicorn
-
-    if args.subcommand == "status":
+    def _status() -> None:
         logger.info("run ispec api start to start the API server")
-    elif args.subcommand == "start":
+
+    def _start() -> None:
+        from ispec.api.main import app
+        import uvicorn
+
         logger.info(f"Starting API server at {args.host}:{args.port}")
         uvicorn.run(app, host=args.host, port=args.port)
-    else:
-        logger.error(f"No handler for subcommand: {args.subcommand}")
+
+    commands = {"status": _status, "start": _start}
+    try:
+        handler = commands[args.subcommand]
+    except KeyError as exc:
+        message = f"No handler for API subcommand: {args.subcommand}"
+        logger.error(message)
+        raise ValueError(message) from exc
+
+    handler()

--- a/src/ispec/cli/db.py
+++ b/src/ispec/cli/db.py
@@ -1,4 +1,3 @@
-from ispec.db import operations
 from ispec.logging import get_logger
 
 
@@ -6,42 +5,32 @@ def register_subcommands(subparsers):
     init_parser = subparsers.add_parser("init", help="initialize db")
     init_parser.add_argument("--file", required=False)
 
-    _ = subparsers.add_parser("status", help="Check DB status")
-    _ = subparsers.add_parser("show", help="Show tables")
+    subparsers.add_parser("status", help="Check DB status")
+    subparsers.add_parser("show", help="Show tables")
 
-    #
     import_parser = subparsers.add_parser("import", help="Import file")
-    import_parser.add_argument(
-        "--table-name", required=True, choices=("person", "project")
-    )
+    import_parser.add_argument("--table-name", required=True, choices=("person", "project"))
     import_parser.add_argument("--file", required=True)
 
 
 def dispatch(args):
-
+    """Dispatch database CLI subcommands with minimal error handling."""
     logger = get_logger(__file__)
-    # funcs = {
-    #     "init" : operations.import_file,
-    #     "status" : operations.check_status,
-    #     "show" : operations.show_tables,
-    #     "import" : operations.import_file,
-    # }
-    # subcommand = args.subcommand
-    # func = funcs.get(subcommand)
-    # if funcs is None:
-    #     raise ValueError(f"subcommand {subcommand} is not configured")
 
-    # todo figure out how to pass the args
-    # unpack all the arguments?
-    # func(args)
+    import ispec.db.operations as operations
 
-    if args.subcommand == "status":
-        operations.check_status()
-    elif args.subcommand == "show":
-        operations.show_tables()
-    elif args.subcommand == "import":
-        operations.import_file(args.file)
-    elif args.subcommand == "init":
-        operations.initialize(file_path=args.file)
-    else:
-        logger.info("no dispatched function provided for %s", args.subcommand)
+    commands = {
+        "status": lambda: operations.check_status(),
+        "show": lambda: operations.show_tables(),
+        "import": lambda: operations.import_file(args.file),
+        "init": lambda: operations.initialize(file_path=args.file),
+    }
+
+    try:
+        handler = commands[args.subcommand]
+    except KeyError as exc:
+        message = f"No handler for DB subcommand: {args.subcommand}"
+        logger.error(message)
+        raise ValueError(message) from exc
+
+    handler()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3] / "src"))
+from ispec.cli import main, db, api
+
+
+def invoke(argv, monkeypatch):
+    monkeypatch.setattr(sys, "argv", argv)
+    main.main()
+
+
+def test_db_subcommand_invokes_dispatch(monkeypatch):
+    called = {}
+
+    def fake_dispatch(args):
+        called["args"] = args
+
+    monkeypatch.setattr(db, "dispatch", fake_dispatch)
+    invoke(["ispec", "db", "status"], monkeypatch)
+    assert called["args"].command == "db"
+    assert called["args"].subcommand == "status"
+
+
+def test_api_subcommand_invokes_dispatch(monkeypatch):
+    called = {}
+
+    def fake_dispatch(args):
+        called["args"] = args
+
+    monkeypatch.setattr(api, "dispatch", fake_dispatch)
+    invoke(["ispec", "api", "status"], monkeypatch)
+    assert called["args"].command == "api"
+    assert called["args"].subcommand == "status"
+
+
+def test_dispatch_errors_propagate(monkeypatch):
+    def boom(args):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(db, "dispatch", boom)
+    with pytest.raises(ValueError, match="boom"):
+        invoke(["ispec", "db", "status"], monkeypatch)
+
+
+def test_api_dispatch_unknown_subcommand():
+    args = SimpleNamespace(subcommand="nope")
+    with pytest.raises(ValueError, match="No handler for API subcommand"):
+        api.dispatch(args)
+
+
+def test_db_dispatch_unknown_subcommand(monkeypatch):
+    dummy_ops = SimpleNamespace(
+        check_status=lambda: None,
+        show_tables=lambda: None,
+        import_file=lambda f: None,
+        initialize=lambda file_path=None: None,
+    )
+    dummy_pkg = ModuleType("db")
+    dummy_pkg.operations = dummy_ops
+    monkeypatch.setitem(sys.modules, "ispec.db", dummy_pkg)
+    monkeypatch.setitem(sys.modules, "ispec.db.operations", dummy_ops)
+    args = SimpleNamespace(subcommand="nope")
+    with pytest.raises(ValueError, match="No handler for DB subcommand"):
+        db.dispatch(args)


### PR DESCRIPTION
## Summary
- replace nested conditionals with lookup tables for CLI dispatch
- raise clear errors for unknown API and DB subcommands
- add unit tests covering CLI entrypoints and dispatch

## Testing
- `pytest -q tests/unit/cli/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ecbc360483329139defa6b0671e1