### PR TITLE
Add integration tests for CLI database workflow

### DIFF
--- a/src/ispec/cli/db.py
+++ b/src/ispec/cli/db.py
@@ -40,7 +40,7 @@ def dispatch(args):
     elif args.subcommand == "show":
         operations.show_tables()
     elif args.subcommand == "import":
-        operations.import_file(args.file)
+        operations.import_file(args.file, args.table_name)
     elif args.subcommand == "init":
         operations.initialize(file_path=args.file)
     else:

--- a/src/ispec/db/operations.py
+++ b/src/ispec/db/operations.py
@@ -1,6 +1,5 @@
-# from ispec.db import init
-# from ispec.db.init import initialize_db
-
+from ispec.db import init
+from ispec.db.init import initialize_db
 from ispec.db.connect import get_session
 from ispec.logging import get_logger
 
@@ -16,7 +15,7 @@ def check_status():
         # for row in session.fetchall():
         #     print(row)
         pass
-    sql_file = init.get_sql_file()
+    init.get_sql_file()
     # logger.info(f"Sql file is : {sql_file}")
 
 
@@ -30,11 +29,11 @@ def show_tables(file_path=None):
         pass
 
 
-def import_file(file_path):
+def import_file(file_path, table_name, db_file_path=None):
     from ispec.io import io_file
 
-    print("preparing to import file.. %s", file_path)
-    io_file.import_file(file_path)
+    logger.info("preparing to import file.. %s", file_path)
+    io_file.import_file(file_path, table_name, db_file_path=db_file_path)
     # need to validate the file input, and understand which table we are meant to update
 
 
@@ -43,3 +42,4 @@ def initialize(file_path=None):
     file_path can be gathered from environment variable or a sensible default if not provided
     """
     return initialize_db(file_path=file_path)
+

--- a/tests/integration/test_cli_db.py
+++ b/tests/integration/test_cli_db.py
@@ -1,0 +1,81 @@
+import sys
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+
+# Ensure the src directory is on the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from ispec.cli.main import main
+
+
+def test_db_init_creates_tables(tmp_path, monkeypatch):
+    """CLI db init should create a SQLite file with tables."""
+
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(sys, "argv", ["ispec", "db", "init", "--file", str(db_file)])
+    main()
+
+    assert db_file.exists()
+
+    with sqlite3.connect(db_file) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table';"
+            )
+        }
+
+    assert "person" in tables
+
+
+def test_cli_import_inserts_data(tmp_path, monkeypatch):
+    """Importing data via the CLI should insert rows into the database."""
+
+    db_file = tmp_path / "test.db"
+
+    # Initialize database
+    monkeypatch.setattr(sys, "argv", ["ispec", "db", "init", "--file", str(db_file)])
+    main()
+    assert db_file.exists()
+
+    # Prepare sample CSV file
+    csv_file = tmp_path / "people.csv"
+    pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "ppl_AddedBy": "tester",
+                "ppl_Name_First": "Alice",
+                "ppl_Name_Last": "Smith",
+            }
+        ]
+    ).to_csv(csv_file, index=False)
+
+    # Ensure import uses the temp database
+    monkeypatch.setenv("ISPEC_DB_PATH", str(db_file))
+
+    # Import data via CLI
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ispec",
+            "db",
+            "import",
+            "--table-name",
+            "person",
+            "--file",
+            str(csv_file),
+        ],
+    )
+    main()
+
+    with sqlite3.connect(db_file) as conn:
+        rows = conn.execute(
+            "SELECT ppl_Name_First, ppl_Name_Last FROM person"
+        ).fetchall()
+
+    assert rows == [("Alice", "Smith")]
+

--- a/tests/integration/test_io_db_integration.py
+++ b/tests/integration/test_io_db_integration.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Ensure the src directory is on the Python path for direct imports
+SRC_PATH = Path(__file__).resolve().parents[2] / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+from ispec.io import io_file
+from ispec.db.connect import get_session
+from ispec.db.models import Person
+from ispec.db import operations
+
+
+def test_import_person_csv_inserts_records(tmp_path):
+    db_path = tmp_path / 'test.db'
+    csv_path = tmp_path / 'people.csv'
+    df = pd.DataFrame([
+        {'ppl_Name_Last': 'Doe', 'ppl_Name_First': 'John', 'ppl_AddedBy': 'tester'}
+    ])
+    df.to_csv(csv_path, index=False)
+
+    io_file.import_file(str(csv_path), 'person', db_file_path=str(db_path))
+
+    with get_session(file_path=str(db_path)) as session:
+        people = session.query(Person).all()
+        assert len(people) == 1
+        person = people[0]
+        assert person.ppl_Name_Last == 'Doe'
+        assert person.ppl_Name_First == 'John'
+
+
+def test_operations_initialize_creates_db_file(tmp_path):
+    db_path = tmp_path / 'cli.db'
+    operations.initialize(file_path=str(db_path))
+    assert db_path.exists()


### PR DESCRIPTION
## Summary
- add database CLI integration tests for initializing and importing data
- fix `operations.import_file` to accept table and optional path
- wire table name through CLI dispatcher
- add integration tests for IO import and operations initialize

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c797eebda48332901bcd306390fdaf