### PR TITLE
Inject UI metadata into schema fields and test column ordering

### DIFF
--- a/src/ispec/api/routes/schema.py
+++ b/src/ispec/api/routes/schema.py
@@ -39,8 +39,19 @@ def build_form_schema(
     # attach per-field UI
     for name, prop in props.items():
         if name in colmap:
-            # prop["ui"] = ui_from_column(colmap[name])
-            prop["ui"] = ui_from_column(colmap[name], route_prefix_for_table=route_prefix_for_table)
+            ui = ui_from_column(
+                colmap[name], route_prefix_for_table=route_prefix_for_table
+            )
+            prop["ui"] = ui
+
+            # also inject into the pydantic field metadata so downstream
+            # consumers can access the information without regenerating the
+            # schema
+            if name in CreateModel.model_fields:
+                field = CreateModel.model_fields[name]
+                extra = dict(getattr(field, "json_schema_extra", {}) or {})
+                extra["ui"] = ui
+                field.json_schema_extra = extra
 
 
     # top-level UI affordances

--- a/tests/unit/api/routes/test_schema.py
+++ b/tests/unit/api/routes/test_schema.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ispec.db.models import Person
+from ispec.api.models.modelmaker import make_pydantic_model_from_sqlalchemy
+from ispec.api.routes.schema import build_form_schema
+from ispec.api.routes.utils.ui_meta import ui_from_column
+
+
+def _get_create_model():
+    return make_pydantic_model_from_sqlalchemy(Person, name_suffix="Create")
+
+
+def test_ui_order_matches_model_column_order():
+    PersonCreate = _get_create_model()
+    schema = build_form_schema(Person, PersonCreate)
+
+    expected_order = [
+        c.name for c in Person.__table__.columns if c.name in PersonCreate.model_fields
+    ]
+    assert schema["ui"]["order"] == expected_order
+
+
+def test_ui_metadata_injected_into_fields():
+    PersonCreate = _get_create_model()
+    schema = build_form_schema(Person, PersonCreate)
+
+    for name, field in PersonCreate.model_fields.items():
+        assert "ui" in field.json_schema_extra, f"missing ui for {name}"
+        expected_ui = ui_from_column(Person.__table__.columns[name])
+        assert field.json_schema_extra["ui"] == expected_ui
+        assert schema["properties"][name]["ui"] == expected_ui


### PR DESCRIPTION
## Summary
- Inject UI hints from `ui_from_column` into Pydantic field metadata in `build_form_schema`
- Add unit tests ensuring schema `ui.order` matches SQLAlchemy column order and that field metadata includes generated UI info

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c79ae62a3083328b8ed50b81f08dd4