### PR TITLE
Add tests for ChatWorker backend behavior and message order

### DIFF
--- a/tests/unit/ai/test_worker.py
+++ b/tests/unit/ai/test_worker.py
@@ -20,3 +20,37 @@ def test_chat_worker_sends_backend(monkeypatch):
     assert sent and sent[0][0] == "http://example.com/api"
     # ensure AI message generated
     assert worker.session.messages[-1].sender == "ai"
+
+
+def test_chat_worker_no_backend_no_call(monkeypatch):
+    called = False
+
+    def fake_put(url, data):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(worker_module, "put_response", fake_put)
+    worker = ChatWorker(backend_url=None)
+    worker.start()
+    worker.enqueue("hi")
+    worker.queue.join()
+    worker.stop()
+
+    assert called is False
+    assert worker.session.messages[-1].sender == "ai"
+
+
+def test_chat_worker_alternating_messages(monkeypatch):
+    # Stub out network interaction just in case
+    monkeypatch.setattr(worker_module, "put_response", lambda *a, **k: None)
+
+    worker = ChatWorker()
+    worker.start()
+    messages = ["one", "two", "three"]
+    for m in messages:
+        worker.enqueue(m)
+    worker.queue.join()
+    worker.stop()
+
+    senders = [msg.sender for msg in worker.session.messages]
+    assert senders == ["user", "ai"] * len(messages)


### PR DESCRIPTION
## Summary
- add tests ensuring ChatWorker skips backend calls when URL is None
- verify enqueued messages produce alternating user and AI messages

## Testing
- `PYTHONPATH=src pytest tests/unit/ai -q`


------
https://chatgpt.com/codex/tasks/task_e_68c79b1818e8833280e616fcd8ec746e