### PR TITLE
Improve TaskQueue robustness and expand tests

### DIFF
--- a/src/ispec/ai/task_queue.py
+++ b/src/ispec/ai/task_queue.py
@@ -40,10 +40,10 @@ class TaskQueue:
 
     def stop(self) -> None:
         """Signal the worker thread to exit and wait for it."""
-
         self._stop_event.set()
-        self._queue.put(None)
-        self._thread.join()
+        if self._thread.is_alive():
+            self._queue.put(None)
+            self._thread.join()
 
     def add_task(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
         """Submit a callable to be executed by the queue."""
@@ -65,5 +65,8 @@ class TaskQueue:
                 break
             try:
                 task.run()
+            except Exception:
+                # Swallow exceptions so one bad task doesn't stop the queue
+                pass
             finally:
                 self._queue.task_done()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+import types
+
+# Ensure the src directory is on the path for imports
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root / 'src'))
+
+# Provide a lightweight stub for requests if it's not installed
+try:
+    import requests  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - executed only when requests missing
+    requests_stub = types.ModuleType('requests')
+    requests_stub.put = lambda *args, **kwargs: None
+    sys.modules['requests'] = requests_stub

--- a/tests/unit/ai/test_task_queue.py
+++ b/tests/unit/ai/test_task_queue.py
@@ -1,5 +1,7 @@
 """Tests for the threaded task queue."""
 
+from unittest.mock import MagicMock
+
 from ispec.ai.task_queue import TaskQueue
 
 
@@ -12,3 +14,61 @@ def test_task_queue_executes_tasks():
     queue.join()
     queue.stop()
     assert results == [1, 2]
+
+
+def test_start_called_only_once():
+    """Starting the queue twice should not spawn extra threads."""
+
+    queue = TaskQueue()
+    original_start = queue._thread.start
+    queue._thread.start = MagicMock(side_effect=original_start)
+
+    queue.start()
+    queue.start()
+    queue.stop()
+
+    assert queue._thread.start.call_count == 1
+
+
+def test_tasks_accept_kwargs():
+    queue = TaskQueue()
+    queue.start()
+
+    results = []
+
+    def record(a, b=None):
+        results.append((a, b))
+
+    queue.add_task(record, 1, b=2)
+    queue.join()
+    queue.stop()
+
+    assert results == [(1, 2)]
+
+
+def test_exception_does_not_stop_queue():
+    queue = TaskQueue()
+    queue.start()
+
+    results = []
+
+    def boom():
+        results.append("boom")
+        raise ValueError("boom")
+
+    def ok():
+        results.append("ok")
+
+    queue.add_task(boom)
+    queue.add_task(ok)
+
+    queue.join()
+    queue.stop()
+
+    assert results == ["boom", "ok"]
+
+
+def test_stop_before_start():
+    queue = TaskQueue()
+    # Should not raise even though the queue hasn't been started
+    queue.stop()


### PR DESCRIPTION
## Summary
- handle tasks that raise exceptions without halting the queue
- guard TaskQueue.stop() when called before start
- add comprehensive TaskQueue tests and test utilities

## Testing
- `pytest tests/unit/ai/test_task_queue.py -q`
- `pytest tests/unit/ai -q`
- `pytest -q` *(fails: No module named 'pydantic', 'ispec.db.connect', 'faker', 'sqlalchemy', 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c79b2106588332be9ae759507b9ca8