### PR TITLE
Add test dependency extras and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,17 @@ readme = "README.md"
 dependencies = [ ]
 requires-python = ">=3.8"
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "numpy",
+    "pandas",
+    "sqlalchemy",
+    "fastapi",
+    "httpx",
+    "faker",
+]
+
 [project.scripts]
 ispec = "ispec.cli:main.main"
 


### PR DESCRIPTION
## Summary
- provide test extras in pyproject for numpy, pandas, and other deps
- add GitHub Actions workflow to install test dependencies and run pytest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7a4e439408332b191c4277456994e