### PR TITLE
Handle unsupported file types in import

### DIFF
--- a/src/ispec/io/io_file.py
+++ b/src/ispec/io/io_file.py
@@ -33,8 +33,7 @@ def get_reader(file: str, **kwargs):
         return partial(pd.read_excel, **kwargs)
 
     else:
-        logger.error(f"do not know how to read file: {file}")
-        return None
+        raise ValueError(f"Unsupported file extension: {file}")
 
 
 def connect_project_person(db_file_path):
@@ -73,8 +72,12 @@ def connect_project_comment(db_file_path):
 
 
 def import_file(file_path, table_name, db_file_path=None, **kwargs):
+    try:
+        reader = get_reader(file_path)
+    except ValueError as exc:
+        logger.error(str(exc))
+        return
 
-    reader = get_reader(file_path)
     df = reader(file_path)
     df = df.replace({np.nan: None}).replace({pd.NaT: None})
     df_dict = df.to_dict(orient="records")

--- a/tests/integration/test_io_db_integration.py
+++ b/tests/integration/test_io_db_integration.py
@@ -36,3 +36,16 @@ def test_operations_initialize_creates_db_file(tmp_path):
     db_path = tmp_path / 'cli.db'
     operations.initialize(file_path=str(db_path))
     assert db_path.exists()
+
+
+def test_import_file_unsupported_extension_logs_error(tmp_path, caplog):
+    db_path = tmp_path / 'test.db'
+    bad_file = tmp_path / 'data.txt'
+    bad_file.write_text('content')
+
+    io_file.logger.addHandler(caplog.handler)
+    with caplog.at_level("ERROR", logger=io_file.logger.name):
+        io_file.import_file(str(bad_file), 'person', db_file_path=str(db_path))
+    io_file.logger.removeHandler(caplog.handler)
+
+    assert "Unsupported file extension" in caplog.text


### PR DESCRIPTION
## Summary
- Raise `ValueError` for unknown file extensions in `get_reader`
- Gracefully handle unsupported file types in `import_file` with clear logging
- Test import error logging for unsupported file types

## Testing
- `pytest tests/integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a87b8a388332a3620c84ac80b6e8