### PR TITLE
refactor: tidy CRUD imports

### DIFF
--- a/src/ispec/db/crud.py
+++ b/src/ispec/db/crud.py
@@ -1,16 +1,10 @@
 # crud.py
-from typing import Dict, Optional, List, Sequence, Any
-from functools import cache
-import sqlite3
-
-from sqlalchemy.orm import Session
-from sqlalchemy import func
+from typing import Any, Iterable, List, Optional, Sequence
 
 from sqlalchemy import select, func, cast
-from sqlalchemy.sql import sqltypes as T   # canonical type classes (String, Text, etc.)
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import sqltypes as T  # canonical type classes (String, Text, etc.)
 
-from ispec.db.connect import get_session
 from ispec.logging import get_logger
 
 


### PR DESCRIPTION
## Summary
- streamline CRUD module imports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c7ae036ca4833297743a0f16e93ee2