### PR TITLE
Remove duplicate ensure_log_dir in logging module

### DIFF
--- a/src/ispec/logging/logging.py
+++ b/src/ispec/logging/logging.py
@@ -7,12 +7,6 @@ from pathlib import Path
 
 _DEFAULT_LOG_DIR = Path(os.environ.get("ISPEC_LOG_DIR", Path.home() / ".ispec" / "logs"))
 _DEFAULT_LOG_FILE = _DEFAULT_LOG_DIR / "ispec.log"
-
-def ensure_log_dir():
-    _DEFAULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
-
-
-
 # Singleton record to track which loggers are already configured
 _LOGGER_INITIALIZED = {}
 


### PR DESCRIPTION
## Summary
- ensure logging module only exposes one parameterized `ensure_log_dir`
- keep standard logging and os imports at module top

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7ae200560833296d46a3ad0e1c120