### PR TITLE
test: cover foreign key ui options

### DIFF
--- a/tests/unit/api/routes/test_schema.py
+++ b/tests/unit/api/routes/test_schema.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ispec.db.models import Person
+from ispec.db.models import Person, ProjectComment
 from ispec.api.models.modelmaker import make_pydantic_model_from_sqlalchemy
 from ispec.api.routes.schema import build_form_schema
 from ispec.api.routes.utils.ui_meta import ui_from_column
@@ -29,3 +29,23 @@ def test_ui_metadata_injected_into_fields():
         expected_ui = ui_from_column(Person.__table__.columns[name])
         assert field.json_schema_extra["ui"] == expected_ui
         assert schema["properties"][name]["ui"] == expected_ui
+
+
+def test_foreign_key_field_uses_route_prefix_mapping():
+    """Foreign key fields should use SelectAsync and mapped route prefix."""
+    CommentCreate = make_pydantic_model_from_sqlalchemy(
+        ProjectComment, name_suffix="Create"
+    )
+
+    mapping = {"project": "/projects"}
+
+    def prefix_for_table(name: str) -> str:
+        return mapping.get(name, f"/{name}")
+
+    schema = build_form_schema(
+        ProjectComment, CommentCreate, route_prefix_for_table=prefix_for_table
+    )
+
+    project_ui = schema["properties"]["project_id"]["ui"]
+    assert project_ui["component"] == "SelectAsync"
+    assert project_ui["optionsEndpoint"] == "/projects/options"


### PR DESCRIPTION
## Summary
- add unit test verifying SelectAsync and routed options endpoint for foreign-key fields

## Testing
- `pytest tests/unit/api/routes/test_schema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7b28aa3c483329878954db4d1095d