### PR TITLE
Refactor CRUD router mapping injection

### DIFF
--- a/tests/unit/api/test_person_router.py
+++ b/tests/unit/api/test_person_router.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from ispec.api.routes.routes import generate_crud_router, ROUTE_PREFIX_BY_TABLE
+from ispec.api.routes.routes import generate_crud_router
 from ispec.db.crud import PersonCRUD
 from ispec.db.models import Person
 from ispec.db.connect import get_session, make_session_factory, sqlite_engine, initialize_db
@@ -15,10 +15,8 @@ def client(tmp_path):
     initialize_db(engine)
     test_session = make_session_factory(engine)
 
-    # ensure clean ROUTE_PREFIX_BY_TABLE for test isolation
-    ROUTE_PREFIX_BY_TABLE.clear()
-
     app = FastAPI()
+    route_prefix_map: dict[str, str] = {}
     person_router = generate_crud_router(
         model=Person,
         crud_class=PersonCRUD,
@@ -26,6 +24,7 @@ def client(tmp_path):
         tag="Person",
         exclude_fields=set(),
         create_exclude_fields={"id", "ppl_CreationTS", "ppl_ModificationTS"},
+        route_prefix_by_table=route_prefix_map,
     )
     app.include_router(person_router)
 
@@ -37,12 +36,13 @@ def client(tmp_path):
 
     with TestClient(app) as client:
         client.session_factory = test_session  # type: ignore[attr-defined]
+        client.route_prefix_map = route_prefix_map  # type: ignore[attr-defined]
         yield client
 
 
 def test_person_router_crud_and_route_prefix(client):
-    # ROUTE_PREFIX_BY_TABLE should register the person table for FK resolution
-    assert ROUTE_PREFIX_BY_TABLE["person"] == "/people"
+    # Route prefix mapping should register the person table for FK resolution
+    assert client.route_prefix_map["person"] == "/people"  # type: ignore[attr-defined]
 
     # schema endpoint should expose model schema
     resp = client.get("/people/schema")


### PR DESCRIPTION
## Summary
- allow `generate_crud_router` to accept an injectable route-prefix mapping to avoid reliance on a module global
- update API router tests to supply and assert their own mapping

## Testing
- `pytest tests/unit/api/test_person_router.py::test_person_router_crud_and_route_prefix -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c7b29859f48332b899308702e67e99