### PR TITLE
Add error handling to API PUT helper

### DIFF
--- a/src/ispec/ai/api.py
+++ b/src/ispec/ai/api.py
@@ -6,8 +6,17 @@ from typing import Any, Dict
 
 import requests
 
+from ispec.logging import get_logger
+
+logger = get_logger(__file__)
+
 
 def put_response(url: str, data: Dict[str, Any]) -> None:
     """Send ``data`` to ``url`` using an HTTP PUT request."""
 
-    requests.put(url, json=data, timeout=5)
+    try:
+        response = requests.put(url, json=data, timeout=5)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Failed to PUT data to %s: %s", url, exc)
+        raise


### PR DESCRIPTION
## Summary
- add logger for API helper
- wrap PUT request in try/except with error logging and status checking

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c7b8440c50833282ab02b2d8e8d73e