### PR TITLE
Clean up CLI placeholder command

### DIFF
--- a/src/ispec/cli/main.py
+++ b/src/ispec/cli/main.py
@@ -1,7 +1,6 @@
 # ispec/cli/main.py
 import argparse
 from ispec.cli import db, api
-from ispec.logging import get_logger
 
 
 def main():
@@ -17,16 +16,11 @@ def main():
     api_subparsers = api_parser.add_subparsers(dest="subcommand", required=True)
     api.register_subcommands(api_subparsers)
 
-    # se_parser = subparsers.add_parser("somethingelse", help="Other stuff")
-    # se_subparsers = se_parser.add_subparsers(dest="subcommand", required=True)
-    # somethingelse.register_subcommands(se_subparsers)
 
     args = parser.parse_args()
 
     # can expand this later, can use a hashmap/dict lookup if becomes larger
     if args.command == "db":
         db.dispatch(args)
-    if args.command == "api":
+    elif args.command == "api":
         api.dispatch(args)
-    elif args.command == "somethingelse":
-        somethingelse.dispatch(args)


### PR DESCRIPTION
## Summary
- remove unused `somethingelse` CLI command and logging import
- simplify dispatch logic to only handle `db` and `api`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7b83065188332a90053efcf3d9c80