### PR TITLE
Auto-start task queue when adding first task

### DIFF
--- a/src/ispec/ai/task_queue.py
+++ b/src/ispec/ai/task_queue.py
@@ -69,8 +69,9 @@ class TaskQueue:
 
     def add_task(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Task:
         """Submit a callable to be executed by the queue."""
-
         task = Task(func, args, kwargs)
+        if not self._started:
+            self.start()
         self._queue.put(task)
         return task
 

--- a/tests/unit/ai/test_task_queue.py
+++ b/tests/unit/ai/test_task_queue.py
@@ -18,6 +18,16 @@ def test_task_queue_executes_tasks():
     assert results == [1, 2]
 
 
+def test_add_task_starts_queue_automatically():
+    """Adding a task should start the queue if needed."""
+    queue = TaskQueue()
+    results: list[int] = []
+    queue.add_task(results.append, 1)
+    queue.join()
+    queue.stop()
+    assert results == [1]
+
+
 def test_start_called_only_once():
     """Starting the queue twice should not spawn extra threads."""
 


### PR DESCRIPTION
## Summary
- start task queue automatically when a task is added and it hasn't started yet
- add unit test to ensure queue auto-starts without explicit start

## Testing
- `python -m pytest tests/unit/ai/test_task_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7bae788248332ba3e02601c993675