### PR TITLE
Ensure get_db_path returns a string URI

### DIFF
--- a/src/ispec/db/connect.py
+++ b/src/ispec/db/connect.py
@@ -26,8 +26,22 @@ def get_db_dir() -> Path:
 
 
 @lru_cache(maxsize=None)
-def get_db_path(file=None) -> Path:
-    db_file = None
+def get_db_path(file: str | Path | None = None) -> str:
+    """Return a SQLite database URI string.
+
+    Parameters
+    ----------
+    file:
+        Optional path to a SQLite database file. When ``None`` the default
+        directory from :func:`get_db_dir` and the filename ``ispec.db`` are
+        used.
+
+    Returns
+    -------
+    str
+        SQLite URI pointing to the database file.
+    """
+
     if file is None:
         db_path = get_db_dir()
         db_file = db_path / "ispec.db"
@@ -98,8 +112,8 @@ def get_session(file_path: str | Path | None = None) -> Session:
     Parameters
     ----------
     file_path:
-        Optional path to the SQLite database file. If not provided, the
-        ``ISPEC_DB_PATH`` environment variable or the default path from
+        Optional path or URI to the SQLite database. If not provided, the
+        ``ISPEC_DB_PATH`` environment variable or the default URI from
         :func:`get_db_path` is used.
     """
 

--- a/tests/unit/db/test_connect.py
+++ b/tests/unit/db/test_connect.py
@@ -19,3 +19,11 @@ def test_get_db_path_custom(tmp_path):
     expected = "sqlite:///" + str(custom)
     assert connect.get_db_path(custom) == expected
 
+
+def test_get_db_path_returns_str(tmp_path, monkeypatch):
+    monkeypatch.setenv("ISPEC_DB_DIR", str(tmp_path))
+    _clear_caches()
+    uri = connect.get_db_path()
+    assert isinstance(uri, str)
+    assert uri.startswith("sqlite:///")
+


### PR DESCRIPTION
## Summary
- Correct `get_db_path` to return a string SQLite URI and document behavior
- Clarify `get_session` docstring about accepting a path or URI
- Add unit test verifying `get_db_path` yields a string URI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7bad90e288332b08938a9c828e7c8