### PR TITLE
Document CLI modules and add parsing tests

### DIFF
--- a/src/ispec/cli/api.py
+++ b/src/ispec/cli/api.py
@@ -1,10 +1,33 @@
-# ispec/cli/api.py
+"""Command-line helpers for controlling the iSPEC API service.
+
+This module exposes functions to register API-related subcommands on an
+``argparse`` parser and to dispatch the parsed arguments to their respective
+handlers.
+"""
+
 from ispec.logging import get_logger
 
 
 def register_subcommands(subparsers):
+    """Register API subcommands on the provided ``argparse`` object.
 
-    status_parser_ = subparsers.add_parser("status", help="Check api status")
+    Parameters
+    ----------
+    subparsers : :class:`argparse._SubParsersAction`
+        The ``argparse`` subparsers object to which API commands are added.
+
+    Examples
+    --------
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser(prog="ispec api")
+    >>> subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    >>> register_subcommands(subparsers)
+    >>> parser.parse_args(["start", "--host", "0.0.0.0", "--port", "9000"])
+    Namespace(subcommand='start', host='0.0.0.0', port=9000)
+
+    """
+
+    _ = subparsers.add_parser("status", help="Check api status")
     starter_parser = subparsers.add_parser("start", help="start the API server")
     starter_parser.add_argument(
         "--host", default="localhost", help="Host to run the API server "
@@ -15,6 +38,26 @@ def register_subcommands(subparsers):
 
 
 def dispatch(args):
+    """Execute the API command associated with ``args.subcommand``.
+
+    Parameters
+    ----------
+    args : :class:`argparse.Namespace`
+        Parsed arguments containing a ``subcommand`` attribute and any
+        additional options required by that subcommand.
+
+    Examples
+    --------
+    >>> import types
+    >>> args = types.SimpleNamespace(subcommand="status")
+    >>> dispatch(args)  # doctest: +SKIP
+
+    When starting the API server::
+
+        >>> args = types.SimpleNamespace(subcommand="start", host="127.0.0.1", port=8000)
+        >>> dispatch(args)  # doctest: +SKIP
+
+    """
 
     logger = get_logger(__file__)
 

--- a/src/ispec/cli/db.py
+++ b/src/ispec/cli/db.py
@@ -1,15 +1,40 @@
+"""Command-line helpers for interacting with the iSPEC database.
+
+This module provides utilities to register database-related subcommands with an
+``argparse`` parser and to dispatch parsed arguments to the appropriate
+database operations.
+"""
+
 from ispec.db import operations
 from ispec.logging import get_logger
 
 
 def register_subcommands(subparsers):
+    """Attach database subcommands to an ``argparse`` parser.
+
+    Parameters
+    ----------
+    subparsers : :class:`argparse._SubParsersAction`
+        The ``argparse`` subparsers object to which database commands will be
+        registered.
+
+    Examples
+    --------
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser(prog="ispec db")
+    >>> subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    >>> register_subcommands(subparsers)
+    >>> parser.parse_args(["init", "--file", "test.db"])
+    Namespace(subcommand='init', file='test.db')
+
+    """
+
     init_parser = subparsers.add_parser("init", help="initialize db")
     init_parser.add_argument("--file", required=False)
 
     _ = subparsers.add_parser("status", help="Check DB status")
     _ = subparsers.add_parser("show", help="Show tables")
 
-    #
     import_parser = subparsers.add_parser("import", help="Import file")
     import_parser.add_argument(
         "--table-name", required=True, choices=("person", "project")
@@ -18,22 +43,28 @@ def register_subcommands(subparsers):
 
 
 def dispatch(args):
+    """Run the database operation associated with ``args.subcommand``.
+
+    Parameters
+    ----------
+    args : :class:`argparse.Namespace`
+        Parsed arguments containing the targeted ``subcommand`` and any
+        additional options required by that subcommand.
+
+    Examples
+    --------
+    >>> import types
+    >>> args = types.SimpleNamespace(subcommand="status")
+    >>> dispatch(args)  # doctest: +SKIP
+
+    Importing data::
+
+        >>> args = types.SimpleNamespace(subcommand="import", file="data.csv", table_name="person")
+        >>> dispatch(args)  # doctest: +SKIP
+
+    """
 
     logger = get_logger(__file__)
-    # funcs = {
-    #     "init" : operations.import_file,
-    #     "status" : operations.check_status,
-    #     "show" : operations.show_tables,
-    #     "import" : operations.import_file,
-    # }
-    # subcommand = args.subcommand
-    # func = funcs.get(subcommand)
-    # if funcs is None:
-    #     raise ValueError(f"subcommand {subcommand} is not configured")
-
-    # todo figure out how to pass the args
-    # unpack all the arguments?
-    # func(args)
 
     if args.subcommand == "status":
         operations.check_status()

--- a/tests/unit/cli/test_api_module.py
+++ b/tests/unit/cli/test_api_module.py
@@ -1,0 +1,54 @@
+import sys
+import argparse
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure the src directory is on the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from ispec.cli import api
+
+
+def test_register_subcommands_parses_start_command():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    api.register_subcommands(subparsers)
+    args = parser.parse_args(["start", "--host", "1.2.3.4", "--port", "1234"])
+    assert args.subcommand == "start"
+    assert args.host == "1.2.3.4"
+    assert args.port == 1234
+
+
+def test_dispatch_start_invokes_uvicorn(monkeypatch):
+    captured = {}
+    dummy_api_main = types.ModuleType("ispec.api.main")
+    dummy_api_main.app = object()
+    dummy_uvicorn = types.ModuleType("uvicorn")
+
+    def fake_run(app, host, port):
+        captured["host"] = host
+        captured["port"] = port
+
+    dummy_uvicorn.run = fake_run
+    monkeypatch.setitem(sys.modules, "ispec.api.main", dummy_api_main)
+    monkeypatch.setitem(sys.modules, "uvicorn", dummy_uvicorn)
+
+    args = types.SimpleNamespace(subcommand="start", host="127.0.0.1", port=9000)
+    api.dispatch(args)
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 9000
+
+
+def test_dispatch_status_does_not_start_server(monkeypatch):
+    run_mock = MagicMock()
+    dummy_api_main = types.ModuleType("ispec.api.main")
+    dummy_api_main.app = object()
+    dummy_uvicorn = types.ModuleType("uvicorn")
+    dummy_uvicorn.run = run_mock
+    monkeypatch.setitem(sys.modules, "ispec.api.main", dummy_api_main)
+    monkeypatch.setitem(sys.modules, "uvicorn", dummy_uvicorn)
+
+    args = types.SimpleNamespace(subcommand="status")
+    api.dispatch(args)
+    run_mock.assert_not_called()

--- a/tests/unit/cli/test_db_module.py
+++ b/tests/unit/cli/test_db_module.py
@@ -1,0 +1,45 @@
+import sys
+import argparse
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure the src directory is on the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from ispec.cli import db
+
+
+def test_register_subcommands_parses_import_command():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    db.register_subcommands(subparsers)
+    args = parser.parse_args(["import", "--table-name", "person", "--file", "people.csv"])
+    assert args.subcommand == "import"
+    assert args.table_name == "person"
+    assert args.file == "people.csv"
+
+
+def test_dispatch_calls_correct_operations(monkeypatch):
+    init_mock = MagicMock()
+    status_mock = MagicMock()
+    show_mock = MagicMock()
+    import_mock = MagicMock()
+    monkeypatch.setattr("ispec.cli.db.operations.initialize", init_mock)
+    monkeypatch.setattr("ispec.cli.db.operations.check_status", status_mock)
+    monkeypatch.setattr("ispec.cli.db.operations.show_tables", show_mock)
+    monkeypatch.setattr("ispec.cli.db.operations.import_file", import_mock)
+
+    db.dispatch(types.SimpleNamespace(subcommand="status"))
+    status_mock.assert_called_once()
+
+    db.dispatch(types.SimpleNamespace(subcommand="show"))
+    show_mock.assert_called_once()
+
+    db.dispatch(types.SimpleNamespace(subcommand="init", file="db.sqlite"))
+    init_mock.assert_called_once_with(file_path="db.sqlite")
+
+    db.dispatch(
+        types.SimpleNamespace(subcommand="import", file="data.csv", table_name="person")
+    )
+    import_mock.assert_called_once_with("data.csv", "person")


### PR DESCRIPTION
## Summary
- document API CLI helpers with detailed module and function docstrings
- document DB CLI helpers with parameter descriptions and examples
- add unit tests validating CLI subcommand parsing and dispatch logic

## Testing
- `pytest tests/unit/cli/test_api_module.py tests/unit/cli/test_db_module.py tests/unit/cli/test_main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c7bace68448332b91f961847b21419