### PR TITLE
Refactor CRUD router helpers

### DIFF
--- a/src/ispec/api/routes/routes.py
+++ b/src/ispec/api/routes/routes.py
@@ -5,39 +5,118 @@ from typing import Type, Callable
 from ispec.db.models import Person, Project, ProjectComment
 from ispec.db.crud import PersonCRUD, ProjectCRUD, ProjectCommentCRUD
 
-from ispec.api.routes.utils.ui_meta import ui_from_column  # used inside schema builder
 from ispec.api.routes.schema import build_form_schema
 
-from ispec.api.models.modelmaker import get_models, make_pydantic_model_from_sqlalchemy
-
-# models = get_models() 
-# ProjectRead = models["ProjectRead"]
-# ProjectUpdate = models["ProjectUpdate"]
+from ispec.api.models.modelmaker import make_pydantic_model_from_sqlalchemy
 
 router = APIRouter()
 
 
-# @router.get("/projects/{project_id}", response_model=ProjectRead)
-# def read_project(project_id: int, db: Session = Depends(get_session)):
-#     project_crud = ProjectCRUD()
-#     return project_crud.get(db, project_id)
+# The router previously relied on a module level ROUTE_PREFIX_BY_TABLE for
+# resolving foreign-key option endpoints.  Global state makes isolated testing
+# difficult, so the mapping is now provided via dependency injection.  Each
+# call to ``generate_crud_router`` accepts a mapping which is shared across
+# routers when needed.
 
 
-# @router.put("/projects/{project_id}", response_model=ProjectRead)
-# def update_project(
-#     project_id: int, payload: ProjectUpdate, db: Session = Depends(get_session)
-# ):
-#     project_crud = ProjectCRUD()
-#     obj = project_crud.get(db, project_id)
-#     for field, value in payload.model_dump(exclude_unset=True).items():
-#         setattr(obj, field, value)
-#     db.commit()
-#     db.refresh(obj)
-#     return obj
+def _add_schema_endpoint(
+    router: APIRouter,
+    model,
+    create_model,
+    *,
+    route_prefix_for_table: Callable[[str], str],
+) -> None:
+    """Register the ``/schema`` endpoint on ``router``."""
+
+    @router.get("/schema")
+    def get_schema():  # pragma: no cover - trivial wrapper
+        return build_form_schema(
+            model, create_model, route_prefix_for_table=route_prefix_for_table
+        )
 
 
+def _add_crud_endpoints(
+    router: APIRouter,
+    crud,
+    read_model,
+    create_model,
+    *,
+    tag: str,
+) -> None:
+    """Attach basic CRUD endpoints to ``router``."""
 
-ROUTE_PREFIX_BY_TABLE: dict[str, str] = {}
+    @router.get("/{item_id}", response_model=read_model, response_model_exclude_none=True)
+    def get_item(item_id: int, db: Session = Depends(get_session)):
+        obj = crud.get(db, item_id)
+        if obj is None:
+            raise HTTPException(status_code=404, detail=f"{tag} not found")
+        return read_model.model_validate(obj).model_dump()
+
+    @router.post(
+        "/",
+        response_model=read_model,
+        response_model_exclude_none=True,
+        summary=f"Create new {tag}",
+        description="Create a new item. Required fields are marked with * in the request body below.",
+        status_code=201,
+    )
+    def create_item(payload: create_model, db: Session = Depends(get_session)):
+        obj = crud.create(db, payload.model_dump())
+        if obj is None:
+            raise HTTPException(status_code=409, detail=f"{tag} already exists")
+        return read_model.model_validate(obj).model_dump()
+
+    @router.put("/{item_id}", response_model=read_model, response_model_exclude_none=True)
+    def update_item(item_id: int, payload: create_model, db: Session = Depends(get_session)):
+        obj = crud.get(db, item_id)
+        if obj is None:
+            raise HTTPException(status_code=404, detail=f"{tag} not found")
+        for field, value in payload.model_dump(exclude_unset=True).items():
+            setattr(obj, field, value)
+        db.commit()
+        db.refresh(obj)
+        return read_model.model_validate(obj).model_dump()
+
+    @router.delete("/{item_id}")
+    def delete_item(item_id: int, db: Session = Depends(get_session)):
+        success = crud.delete(db, item_id)
+        if not success:
+            raise HTTPException(status_code=404, detail=f"{tag} not found")
+        return {"status": "deleted", "id": item_id}
+
+
+def _add_options_endpoints(router: APIRouter, crud, *, model) -> None:
+    """Attach ``/options`` endpoints for async select components."""
+
+    @router.get("/options")
+    def options(
+        q: str | None = None,
+        limit: int = Query(default=20, ge=1, le=100),
+        ids: list[int] | None = Query(default=None),
+        exclude_ids: list[int] | None = Query(default=None),
+        db: Session = Depends(get_session),
+    ):
+        return crud.list_options(
+            db, q=q, limit=limit, ids=ids, exclude_ids=exclude_ids
+        )
+
+    @router.get("/options/{field}")
+    def options_for_field(
+        field: str,
+        q: str | None = None,
+        limit: int = 20,
+        db: Session = Depends(get_session),
+    ):
+        from sqlalchemy import inspect as sa_inspect
+
+        mapper = sa_inspect(model)
+        rel = mapper.relationships.get(field)
+        if not rel:
+            raise HTTPException(status_code=404, detail=f"No relationship named '{field}'")
+        target_cls = rel.mapper.class_
+        target_crud = crud.__class__()
+        target_crud.model = target_cls
+        return target_crud.list_options(db, q=q, limit=limit)
 
 
 def generate_crud_router(
@@ -91,9 +170,9 @@ def generate_crud_router(
         If True, marks all fields in the create/update model as optional.
 
     route_prefix_by_table : dict[str, str] | None, default=None
-        Mapping of table names to route prefixes. If not provided, a module-level
-        global registry is used. This is primarily useful for testing to avoid
-        mutating global state.
+        Mapping of table names to route prefixes.  When multiple routers are
+        generated the mapping should be shared so that foreign-key fields can
+        resolve the appropriate ``/options`` endpoint for related tables.
 
     Returns
     -------
@@ -118,7 +197,7 @@ def generate_crud_router(
     router = APIRouter(prefix=prefix, tags=[tag])
     crud = crud_class()
 
-    prefix_map = route_prefix_by_table if route_prefix_by_table is not None else ROUTE_PREFIX_BY_TABLE
+    prefix_map = route_prefix_by_table if route_prefix_by_table is not None else {}
 
     # register prefix for FK resolution (e.g., "person" -> "/people")
     prefix_map[model.__table__.name] = prefix
@@ -126,125 +205,24 @@ def generate_crud_router(
     def route_prefix_for_table(table: str) -> str:
         return prefix_map.get(table, f"/{table}")
 
-
-    # Generate models
     ReadModel = make_pydantic_model_from_sqlalchemy(
         model,
         name_suffix="Read",
-        # strip_prefix=strip_prefix,
     )
     CreateModel = make_pydantic_model_from_sqlalchemy(
         model,
         name_suffix="Create",
-        # strip_prefix=strip_prefix,
         exclude_fields={*exclude_fields, *create_exclude_fields},
         optional_all=optional_all,
-        # exclude_fields = {""}
     )
 
-    # this is for frontend UI form rendering
-    @router.get("/schema")
-    def get_schema():
-        return build_form_schema(model, CreateModel, route_prefix_for_table=route_prefix_for_table)
-
-        # this is now in build_form_schema
-        # schema = CreateModel.model_json_schema()
-        # # attach per-field UI hints
-        # props = schema.get("properties", {})
-        # column_map = {c.name: c for c in model.__table__.columns}  # type: ignore
-        # for name, prop in props.items():
-        #     col = column_map.get(name)
-        #     if col is None:
-        #         continue
-        #     prop["ui"] = ui_from_column(col)
-        #     # carry ordering/grouping if present on SA Column
-        #     if grp := (col.info or {}).get("group"):
-        #         prop.setdefault("ui", {})["group"] = grp
-
-        # # top-level UI (sections/order) — optional
-        # schema["ui"] = {
-        #     "order": [c.name for c in model.__table__.columns if c.name in props],
-        #     "sections": [],  # you can prefill from model-level metadata if desired
-        #     "title": tag,
-        # }
-        # return schema
-
-    @router.get("/{item_id}", response_model=ReadModel, response_model_exclude_none=True)
-    def get_item(item_id: int, db: Session = Depends(get_session)):
-        obj = crud.get(db, item_id)
-        if obj is None:
-            raise HTTPException(status_code=404, detail=f"{tag} not found")
-        return ReadModel.model_validate(obj)
-
-    @router.post(
-        "/",
-        response_model=ReadModel,
-        response_model_exclude_none=True,
-        summary=f"Create new {tag}",
-        description="Create a new item. Required fields are marked with * in the request body below.",
-        status_code=201,
+    _add_schema_endpoint(
+        router, model, CreateModel, route_prefix_for_table=route_prefix_for_table
     )
-    def create_item(payload: CreateModel, db: Session = Depends(get_session)):
-        obj = crud.create(db, payload.model_dump())
-        if obj is None:
-            raise HTTPException(status_code=409, detail=f"{tag} already exists")
-        return ReadModel.model_validate(obj)
-
-    @router.put("/{item_id}", response_model=ReadModel, response_model_exclude_none=True)
-    def update_item(
-        item_id: int, payload: CreateModel, db: Session = Depends(get_session)
-    ):
-        obj = crud.get(db, item_id)
-        if obj is None:
-            raise HTTPException(status_code=404, detail=f"{tag} not found")
-        for field, value in payload.model_dump(exclude_unset=True).items():
-            setattr(obj, field, value)
-        db.commit()
-        db.refresh(obj)
-        return ReadModel.model_validate(obj)
-
-    @router.delete("/{item_id}")
-    def delete_item(item_id: int, db: Session = Depends(get_session)):
-        success = crud.delete(db, item_id)
-        if not success:
-            raise HTTPException(status_code=404, detail=f"{tag} not found")
-        return {"status": "deleted", "id": item_id}
-
-
-    @router.get("/options")
-    def options(
-        q: str | None = None,
-        limit: int = Query(default=20, ge=1, le=100),
-        ids: list[int] | None = Query(default=None),
-        exclude_ids: list[int] | None = Query(default=None),
-        db: Session = Depends(get_session),
-    ):
-        return crud.list_options(db, q=q, limit=limit, ids=ids, exclude_ids=exclude_ids)
-
-    # this is WIP
-    @router.get("/options/{field}")
-    def options_for_field(
-        field: str,
-        q: str | None = None,
-        limit: int = 20,
-        db: Session = Depends(get_session),
-    ):
-        # Resolve the related model via ORM relationship
-        from sqlalchemy import inspect as sa_inspect
-
-        mapper = sa_inspect(model)
-        rel = mapper.relationships.get(field)
-        if not rel:
-            raise HTTPException(
-                status_code=404, detail=f"No relationship named '{field}'"
-            )
-        target_cls = rel.mapper.class_
-        # Use the target's CRUD (you can keep a registry {Model: CRUD})
-        target_crud = (
-            crud.__class__()
-        )  # if your CRUDs share a base, use a registry instead
-        target_crud.model = target_cls
-        return target_crud.list_options(db, q=q, limit=limit)
+    _add_crud_endpoints(
+        router, crud, ReadModel, CreateModel, tag=tag
+    )
+    _add_options_endpoints(router, crud, model=model)
 
     return router
 
@@ -264,6 +242,8 @@ def generate_crud_router(
 # other things
 
 # ========================= Person ==============================
+_ROUTE_PREFIX_MAP: dict[str, str] = {}
+
 router.include_router(
     generate_crud_router(
         model=Person,
@@ -275,6 +255,7 @@ router.include_router(
             "id",
         },
         create_exclude_fields={"ppl_CreationTS", "ppl_ModificationTS"},
+        route_prefix_by_table=_ROUTE_PREFIX_MAP,
     )
 )
 
@@ -288,6 +269,7 @@ router.include_router(
         tag="Project",
         # strip_prefix="prj_",
         exclude_fields={"id"},
+        route_prefix_by_table=_ROUTE_PREFIX_MAP,
     )
 )
 
@@ -301,6 +283,7 @@ router.include_router(
         tag="ProjectComment",
         # strip_prefix="com_",
         exclude_fields={"id"},
+        route_prefix_by_table=_ROUTE_PREFIX_MAP,
     )
 )
 

--- a/tests/unit/api/routes/test_helpers.py
+++ b/tests/unit/api/routes/test_helpers.py
@@ -1,0 +1,126 @@
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from ispec.api.routes.routes import (
+    _add_schema_endpoint,
+    _add_crud_endpoints,
+    _add_options_endpoints,
+)
+from ispec.api.models.modelmaker import make_pydantic_model_from_sqlalchemy
+from ispec.db.models import Person
+from ispec.db.crud import PersonCRUD
+from ispec.db.connect import get_session, make_session_factory, sqlite_engine, initialize_db
+
+
+def test_add_schema_endpoint_exposes_schema():
+    router = APIRouter(prefix="/people", tags=["Person"])
+    PersonCreate = make_pydantic_model_from_sqlalchemy(Person, name_suffix="Create")
+
+    mapping = {"person": "/people"}
+
+    def prefix_for_table(name: str) -> str:
+        return mapping.get(name, f"/{name}")
+
+    _add_schema_endpoint(router, Person, PersonCreate, route_prefix_for_table=prefix_for_table)
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    resp = client.get("/people/schema")
+    assert resp.status_code == 200
+    assert "ppl_Name_First" in resp.json()["properties"]
+
+
+@pytest.fixture
+def crud_client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/crud.db"
+    engine = sqlite_engine(db_url)
+    initialize_db(engine)
+    session_factory = make_session_factory(engine)
+
+    router = APIRouter(prefix="/people", tags=["Person"])
+    crud = PersonCRUD()
+    ReadModel = make_pydantic_model_from_sqlalchemy(
+        Person, name_suffix="Read", exclude_fields=set()
+    )
+    CreateModel = make_pydantic_model_from_sqlalchemy(
+        Person,
+        name_suffix="Create",
+        exclude_fields={"id", "ppl_CreationTS", "ppl_ModificationTS"},
+    )
+    _add_crud_endpoints(router, crud, ReadModel, CreateModel, tag="Person")
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def override_session():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_session
+
+    with TestClient(app) as client:
+        client.session_factory = session_factory  # type: ignore[attr-defined]
+        yield client
+
+
+def test_add_crud_endpoints_crud_operations(crud_client):
+    payload = {
+        "ppl_Name_First": "Jane",
+        "ppl_Name_Last": "Doe",
+        "ppl_AddedBy": "tester",
+    }
+    resp = crud_client.post("/people/", json=payload)
+    assert resp.status_code == 201
+    person_id = resp.json()["id"]
+
+    resp = crud_client.get(f"/people/{person_id}")
+    assert resp.status_code == 200
+    assert resp.json()["ppl_Name_First"] == "Jane"
+
+    resp = crud_client.delete(f"/people/{person_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+
+@pytest.fixture
+def options_client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/opts.db"
+    engine = sqlite_engine(db_url)
+    initialize_db(engine)
+    session_factory = make_session_factory(engine)
+
+    router = APIRouter(prefix="/people", tags=["Person"])
+    crud = PersonCRUD()
+    _add_options_endpoints(router, crud, model=Person)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def override_session():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_session
+
+    with TestClient(app) as client:
+        client.session_factory = session_factory  # type: ignore[attr-defined]
+        yield client
+
+
+def test_add_options_endpoints_returns_options(options_client):
+    with options_client.session_factory() as db:  # type: ignore[attr-defined]
+        PersonCRUD().create(
+            db,
+            {
+                "ppl_Name_First": "John",
+                "ppl_Name_Last": "Doe",
+                "ppl_AddedBy": "tester",
+            },
+        )
+
+    resp = options_client.get("/people/options")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data and data[0]["value"] > 0


### PR DESCRIPTION
## Summary
- refactor router generation into private helpers for schema, CRUD, and options endpoints
- drop global route prefix mapping in favor of injected map
- add unit tests exercising schema, CRUD, and options helper functions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7bad557248332a81bceac04ec1a3c