### PR TITLE
Add logger reset utility

### DIFF
--- a/src/ispec/logging/__init__.py
+++ b/src/ispec/logging/__init__.py
@@ -1,2 +1,2 @@
 # src/ispec/logging/__init__.py
-from .logging import get_logger 
+from .logging import get_logger, reset_logger

--- a/src/ispec/logging/logging.py
+++ b/src/ispec/logging/logging.py
@@ -74,3 +74,36 @@ def get_logger(
         _LOGGER_INITIALIZED[name] = True
 
     return logger
+
+
+def reset_logger(name=None):
+    """Reset configured loggers so they can be reconfigured.
+
+    Parameters
+    ----------
+    name : str, optional
+        Name of the logger to reset. If omitted, all loggers tracked by
+        :func:`get_logger` are reset.
+
+    Examples
+    --------
+    >>> logger = get_logger("demo", level=logging.DEBUG)
+    >>> reset_logger("demo")
+    >>> logger = get_logger("demo", level=logging.INFO)
+    """
+    if name is None:
+        names = list(_LOGGER_INITIALIZED.keys())
+    else:
+        names = [name]
+
+    for n in names:
+        logger = logging.getLogger(n)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+
+    if name is None:
+        _LOGGER_INITIALIZED.clear()
+    else:
+        _LOGGER_INITIALIZED.pop(name, None)
+

--- a/tests/unit/logging/test_logging.py
+++ b/tests/unit/logging/test_logging.py
@@ -1,0 +1,33 @@
+"""Tests for logging utilities."""
+
+import logging
+
+from ispec.logging import get_logger, reset_logger
+
+
+def test_reset_logger_allows_reconfiguration(tmp_path):
+    log1 = tmp_path / "first.log"
+    log2 = tmp_path / "second.log"
+
+    # Initial configuration writes to the first file
+    logger = get_logger("test", log_file=log1, console=False)
+    logger.info("first message")
+    for handler in logger.handlers:
+        handler.flush()
+
+    assert "first message" in log1.read_text()
+
+    # Reset and ensure logger has no handlers
+    reset_logger()
+    assert logging.getLogger("test").handlers == []
+
+    # Reconfigure to write to the second file
+    logger2 = get_logger("test", log_file=log2, console=False)
+    logger2.info("second message")
+    for handler in logger2.handlers:
+        handler.flush()
+
+    assert "second message" in log2.read_text()
+    # Ensure the old file did not receive the new message
+    assert "second message" not in log1.read_text()
+


### PR DESCRIPTION
## Summary
- expose `reset_logger` to clear handlers and initialization state
- allow reconfiguring loggers after reset with new tests

## Testing
- `pytest tests/unit/logging/test_logging.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c7bae1c4bc833291aa4b83c387bbc0