### PR TITLE
Add module docstrings and public exports

### DIFF
--- a/src/ispec/__init__.py
+++ b/src/ispec/__init__.py
@@ -1,0 +1,11 @@
+"""Core package for the iSPEC project.
+
+This top-level module exposes convenience helpers such as
+the database :func:`get_session` function for interacting with
+the project's persistence layer.
+"""
+
+from .db import get_session
+
+__all__ = ["get_session"]
+

--- a/src/ispec/api/__init__.py
+++ b/src/ispec/api/__init__.py
@@ -1,0 +1,6 @@
+"""API package exposing the FastAPI application for iSPEC."""
+
+from .main import app
+
+__all__ = ["app"]
+

--- a/src/ispec/cli/__init__.py
+++ b/src/ispec/cli/__init__.py
@@ -1,0 +1,6 @@
+"""Command-line interface utilities for iSPEC."""
+
+from .main import main
+
+__all__ = ["main"]
+


### PR DESCRIPTION
## Summary
- Document top-level `ispec` package and expose `get_session` helper
- Add API package docstring and export FastAPI `app`
- Document CLI package and expose `main` entry point

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c7c0fae2988332b3e5325ad72935a1