### PR TITLE
docs: add module docstring to ui_meta

### DIFF
--- a/src/ispec/api/routes/utils/ui_meta.py
+++ b/src/ispec/api/routes/utils/ui_meta.py
@@ -1,4 +1,10 @@
 # utils/ui_meta.py
+"""Generate UI metadata from SQLAlchemy columns.
+
+This module offers helpers, such as :func:`ui_from_column`, to infer UI
+components and options from SQLAlchemy ``Column`` objects.
+"""
+
 from __future__ import annotations
 from typing import Any, Callable
 from sqlalchemy import Column as SAColumn, types as T


### PR DESCRIPTION
## Summary
- add module docstring describing UI metadata helpers derived from SQLAlchemy columns

## Testing
- `pytest` *(fails: No module named fastapi, pandas, sqlalchemy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c0e99cf08332b49d287f1ca08416