### PR TITLE
Fix ProjectNote input validation for identifier

### DIFF
--- a/src/ispec/db/crud.py
+++ b/src/ispec/db/crud.py
@@ -529,7 +529,7 @@ class ProjectNote(TableCRUD):
     def validate_input(self, record: dict):
         record = super().validate_input(record)
         i_id = record.get("i_id")
-        if not id:
+        if not i_id:
             return None
         return record
 


### PR DESCRIPTION
## Summary
- fix ProjectNote.validate_input to test `i_id` instead of builtin `id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7c0f3848c83328ce45ec7ee32a220