### PR TITLE
Add database export command

### DIFF
--- a/src/ispec/cli/db.py
+++ b/src/ispec/cli/db.py
@@ -27,6 +27,11 @@ def register_subcommands(subparsers):
     >>> parser.parse_args(["init", "--file", "test.db"])
     Namespace(subcommand='init', file='test.db')
 
+    Exporting data::
+
+    >>> parser.parse_args(["export", "--table-name", "person", "--file", "out.csv"])
+    Namespace(subcommand='export', table_name='person', file='out.csv')
+
     """
 
     init_parser = subparsers.add_parser("init", help="initialize db")
@@ -40,6 +45,10 @@ def register_subcommands(subparsers):
         "--table-name", required=True, choices=("person", "project")
     )
     import_parser.add_argument("--file", required=True)
+
+    export_parser = subparsers.add_parser("export", help="Export table to CSV")
+    export_parser.add_argument("--table-name", required=True, choices=("person", "project"))
+    export_parser.add_argument("--file", required=True, help="Output CSV file")
 
 
 def dispatch(args):
@@ -62,6 +71,11 @@ def dispatch(args):
         >>> args = types.SimpleNamespace(subcommand="import", file="data.csv", table_name="person")
         >>> dispatch(args)  # doctest: +SKIP
 
+    Exporting data::
+
+        >>> args = types.SimpleNamespace(subcommand="export", table_name="person", file="out.csv")
+        >>> dispatch(args)  # doctest: +SKIP
+
     """
 
     logger = get_logger(__file__)
@@ -72,6 +86,8 @@ def dispatch(args):
         operations.show_tables()
     elif args.subcommand == "import":
         operations.import_file(args.file, args.table_name)
+    elif args.subcommand == "export":
+        operations.export_table(args.table_name, args.file)
     elif args.subcommand == "init":
         operations.initialize(file_path=args.file)
     else:

--- a/src/ispec/db/operations.py
+++ b/src/ispec/db/operations.py
@@ -1,4 +1,5 @@
 from sqlalchemy import text
+import pandas as pd
 
 from ispec.db.init import initialize_db
 from ispec.db.connect import get_session
@@ -46,4 +47,21 @@ def initialize(file_path=None):
     file_path can be gathered from environment variable or a sensible default if not provided
     """
     return initialize_db(file_path=file_path)
+
+
+def export_table(table_name: str, file_path: str) -> None:
+    """Export a database table to a CSV file.
+
+    Parameters
+    ----------
+    table_name:
+        Name of the table to export.
+    file_path:
+        Destination path for the CSV file.
+    """
+
+    logger.info("exporting table %s to %s", table_name, file_path)
+    with get_session() as session:
+        df = pd.read_sql_table(table_name, session.bind)
+    df.to_csv(file_path, index=False)
 

--- a/tests/integration/test_cli_db.py
+++ b/tests/integration/test_cli_db.py
@@ -81,6 +81,66 @@ def test_cli_import_inserts_data(tmp_path, monkeypatch):
     assert rows == [("Alice", "Smith")]
 
 
+def test_cli_export_writes_csv(tmp_path, monkeypatch):
+    """Exporting data via the CLI should create a CSV file with table rows."""
+
+    db_file = tmp_path / "test.db"
+
+    # Initialize database
+    monkeypatch.setattr(sys, "argv", ["ispec", "db", "init", "--file", str(db_file)])
+    main()
+    assert db_file.exists()
+
+    # Prepare and import sample data
+    csv_file = tmp_path / "people.csv"
+    pd.DataFrame(
+        [
+            {
+                "id": 1,
+                "ppl_AddedBy": "tester",
+                "ppl_Name_First": "Alice",
+                "ppl_Name_Last": "Smith",
+            }
+        ]
+    ).to_csv(csv_file, index=False)
+
+    monkeypatch.setenv("ISPEC_DB_PATH", str(db_file))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ispec",
+            "db",
+            "import",
+            "--table-name",
+            "person",
+            "--file",
+            str(csv_file),
+        ],
+    )
+    main()
+
+    # Export table
+    export_file = tmp_path / "export.csv"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ispec",
+            "db",
+            "export",
+            "--table-name",
+            "person",
+            "--file",
+            str(export_file),
+        ],
+    )
+    main()
+
+    df = pd.read_csv(export_file)
+    assert df.iloc[0]["ppl_Name_First"] == "Alice"
+
+
 def test_db_status_prints_sqlite_version(tmp_path, monkeypatch, caplog):
     """Running `ispec db status` should output the SQLite version."""
 

--- a/tests/unit/cli/test_db_module.py
+++ b/tests/unit/cli/test_db_module.py
@@ -20,15 +20,27 @@ def test_register_subcommands_parses_import_command():
     assert args.file == "people.csv"
 
 
+def test_register_subcommands_parses_export_command():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    db.register_subcommands(subparsers)
+    args = parser.parse_args(["export", "--table-name", "person", "--file", "out.csv"])
+    assert args.subcommand == "export"
+    assert args.table_name == "person"
+    assert args.file == "out.csv"
+
+
 def test_dispatch_calls_correct_operations(monkeypatch):
     init_mock = MagicMock()
     status_mock = MagicMock()
     show_mock = MagicMock()
     import_mock = MagicMock()
+    export_mock = MagicMock()
     monkeypatch.setattr("ispec.cli.db.operations.initialize", init_mock)
     monkeypatch.setattr("ispec.cli.db.operations.check_status", status_mock)
     monkeypatch.setattr("ispec.cli.db.operations.show_tables", show_mock)
     monkeypatch.setattr("ispec.cli.db.operations.import_file", import_mock)
+    monkeypatch.setattr("ispec.cli.db.operations.export_table", export_mock)
 
     db.dispatch(types.SimpleNamespace(subcommand="status"))
     status_mock.assert_called_once()
@@ -43,3 +55,10 @@ def test_dispatch_calls_correct_operations(monkeypatch):
         types.SimpleNamespace(subcommand="import", file="data.csv", table_name="person")
     )
     import_mock.assert_called_once_with("data.csv", "person")
+
+    db.dispatch(
+        types.SimpleNamespace(
+            subcommand="export", table_name="person", file="out.csv"
+        )
+    )
+    export_mock.assert_called_once_with("person", "out.csv")

--- a/tests/unit/db/test_operations.py
+++ b/tests/unit/db/test_operations.py
@@ -1,5 +1,4 @@
 import logging
-
 import pytest
 
 from ispec.db import operations
@@ -31,3 +30,25 @@ def test_show_tables_logs_tables(tmp_path, monkeypatch, caplog):
     finally:
         logger.propagate = orig_prop
     assert "person" in caplog.text
+
+
+def test_export_table_writes_csv(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("ISPEC_DB_PATH", str(db_path))
+
+    from ispec.db.connect import get_session
+    from sqlalchemy import text
+    import pandas as pd
+
+    with get_session() as session:
+        session.execute(
+            text(
+                "INSERT INTO person (ppl_Name_First, ppl_Name_Last, ppl_AddedBy, ppl_CreationTS, ppl_ModificationTS) "
+                "VALUES ('Alice', 'Smith', 'tester', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            )
+        )
+
+    export_file = tmp_path / "out.csv"
+    operations.export_table("person", str(export_file))
+    df = pd.read_csv(export_file)
+    assert df.loc[0, "ppl_Name_First"] == "Alice"


### PR DESCRIPTION
## Summary
- implement `export_table` to dump SQLite tables to CSV using pandas
- add `ispec db export` CLI subcommand
- test table exports through unit and integration tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8356d18888332832837ba9c6f124a