### PR TITLE
Add logging CLI utilities for level and path

### DIFF
--- a/src/ispec/cli/logging.py
+++ b/src/ispec/cli/logging.py
@@ -1,0 +1,46 @@
+"""Command-line helpers for configuring iSPEC logging.
+
+This module exposes functions to register logging-related subcommands on an
+``argparse`` parser and to dispatch the parsed arguments to their respective
+handlers.
+"""
+
+import logging
+
+from ispec.logging import get_logger, reset_logger
+from ispec.logging.logging import _resolve_log_file
+
+
+def register_subcommands(subparsers):
+    """Register logging subcommands on the provided ``argparse`` object.
+
+    Parameters
+    ----------
+    subparsers : :class:`argparse._SubParsersAction`
+        The ``argparse`` subparsers object to which logging commands are added.
+    """
+
+    set_level_parser = subparsers.add_parser(
+        "set-level", help="Set the logging level"
+    )
+    set_level_parser.add_argument(
+        "level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level to use",
+    )
+
+    subparsers.add_parser("show-path", help="Show the log file location")
+
+
+def dispatch(args):
+    """Execute the logging command associated with ``args.subcommand``."""
+
+    if args.subcommand == "set-level":
+        level = getattr(logging, args.level.upper())
+        reset_logger()
+        get_logger(level=level)
+    elif args.subcommand == "show-path":
+        path = _resolve_log_file().resolve()
+        print(path)
+    else:
+        get_logger(__file__).error("No handler for subcommand: %s", args.subcommand)

--- a/src/ispec/cli/main.py
+++ b/src/ispec/cli/main.py
@@ -1,6 +1,6 @@
 # ispec/cli/main.py
 import argparse
-from ispec.cli import db, api
+from ispec.cli import api, db, logging as logging_cli
 
 
 def main():
@@ -16,6 +16,12 @@ def main():
     api_subparsers = api_parser.add_subparsers(dest="subcommand", required=True)
     api.register_subcommands(api_subparsers)
 
+    logging_parser = subparsers.add_parser("logging", help="Logging utilities")
+    logging_subparsers = logging_parser.add_subparsers(
+        dest="subcommand", required=True
+    )
+    logging_cli.register_subcommands(logging_subparsers)
+
 
     args = parser.parse_args()
 
@@ -24,3 +30,5 @@ def main():
         db.dispatch(args)
     elif args.command == "api":
         api.dispatch(args)
+    elif args.command == "logging":
+        logging_cli.dispatch(args)

--- a/tests/unit/cli/test_logging_module.py
+++ b/tests/unit/cli/test_logging_module.py
@@ -1,0 +1,40 @@
+import sys
+import argparse
+import types
+from pathlib import Path
+import logging
+from unittest.mock import MagicMock
+
+# Ensure the src directory is on the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from ispec.cli import logging as logging_cli
+
+
+def test_register_subcommands_parses_set_level():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    logging_cli.register_subcommands(subparsers)
+    args = parser.parse_args(["set-level", "DEBUG"])
+    assert args.subcommand == "set-level"
+    assert args.level == "DEBUG"
+
+
+def test_dispatch_set_level_invokes_logging_helpers(monkeypatch):
+    reset_mock = MagicMock()
+    get_mock = MagicMock()
+    monkeypatch.setattr(logging_cli, "reset_logger", reset_mock)
+    monkeypatch.setattr(logging_cli, "get_logger", get_mock)
+    args = types.SimpleNamespace(subcommand="set-level", level="INFO")
+    logging_cli.dispatch(args)
+    reset_mock.assert_called_once_with()
+    get_mock.assert_called_once()
+    assert get_mock.call_args.kwargs["level"] == logging.INFO
+
+
+def test_dispatch_show_path_prints_resolved_path(monkeypatch, capsys):
+    expected = Path("/tmp/ispec-test.log")
+    monkeypatch.setattr(logging_cli, "_resolve_log_file", lambda: expected)
+    args = types.SimpleNamespace(subcommand="show-path")
+    logging_cli.dispatch(args)
+    assert capsys.readouterr().out.strip() == str(expected.resolve())

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import logging
 from unittest.mock import MagicMock
 
 # Ensure the src directory is on the Python path
@@ -74,3 +75,22 @@ def test_api_start(monkeypatch):
     run_mock.assert_called_once()
     assert run_mock.call_args.kwargs["host"] == "0.0.0.0"
     assert run_mock.call_args.kwargs["port"] == 5000
+
+
+def test_logging_set_level(monkeypatch):
+    reset_mock = MagicMock()
+    get_mock = MagicMock()
+    monkeypatch.setattr("ispec.cli.logging.reset_logger", reset_mock)
+    monkeypatch.setattr("ispec.cli.logging.get_logger", get_mock)
+    monkeypatch.setattr(sys, "argv", ["ispec", "logging", "set-level", "WARNING"])
+    main()
+    reset_mock.assert_called_once_with()
+    assert get_mock.call_args.kwargs["level"] == logging.WARNING
+
+
+def test_logging_show_path(monkeypatch, capsys):
+    path = Path("/tmp/ispec.log")
+    monkeypatch.setattr("ispec.cli.logging._resolve_log_file", lambda: path)
+    monkeypatch.setattr(sys, "argv", ["ispec", "logging", "show-path"])
+    main()
+    assert capsys.readouterr().out.strip() == str(path.resolve())


### PR DESCRIPTION
## Summary
- add `logging` command group with `set-level` and `show-path`
- expose logging helper module to configure level and display log file
- test new CLI subcommands and ensure main router dispatches them

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c83573dc208332815c5cf20e794b42