### PR TITLE
Enhance ispec db show with rich table output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A Python package for database"
 authors = [{ name = "Your Name", email = "alexander.saltzman@bcm.edu" }]
 license = { file = "LICENSE" }
 readme = "README.md"
-dependencies = ["requests", "uvicorn"]
+dependencies = ["requests", "uvicorn", "rich"]
 requires-python = ">=3.8"
 
 [project.optional-dependencies]

--- a/tests/unit/db/test_operations.py
+++ b/tests/unit/db/test_operations.py
@@ -26,10 +26,15 @@ def test_show_tables_logs_tables(tmp_path, monkeypatch, caplog):
     logger.propagate = True
     try:
         with caplog.at_level(logging.INFO):
-            operations.show_tables()
+            tables = operations.show_tables()
     finally:
         logger.propagate = orig_prop
     assert "person" in caplog.text
+    assert "person" in tables
+    person_columns = {column["name"]: column for column in tables["person"]}
+    assert "ppl_Name_First" in person_columns
+    assert not person_columns["ppl_Name_First"]["nullable"]
+    assert "TEXT" in person_columns["ppl_Name_First"]["type"].upper()
 
 
 def test_export_table_writes_csv(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- update the database show operation to return column metadata for each table
- add a rich-powered renderer so `ispec db show` prints a formatted table of columns
- declare the new dependency and extend tests to cover the richer output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8542ece3483328e3a643e8ea556dc