### PR TITLE
Improve API CLI status reporting

### DIFF
--- a/src/ispec/cli/api.py
+++ b/src/ispec/cli/api.py
@@ -5,7 +5,130 @@ This module exposes functions to register API-related subcommands on an
 handlers.
 """
 
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import requests
+
 from ispec.logging import get_logger
+
+_STATUS_ENDPOINT = "/status"
+_STATE_FILE_ENV = "ISPEC_API_STATE_FILE"
+_STATE_DIR_ENV = "ISPEC_STATE_DIR"
+_STATE_FILENAME = "api_server.json"
+_REQUEST_TIMEOUT = 2.0
+
+
+def _state_file_path() -> Path:
+    """Return the filesystem path used to persist API server state."""
+
+    override = os.environ.get(_STATE_FILE_ENV)
+    if override:
+        return Path(override)
+
+    base_dir = Path(os.environ.get(_STATE_DIR_ENV, Path.home() / ".ispec"))
+    return base_dir / _STATE_FILENAME
+
+
+def _write_state(host: str, port: int, *, logger) -> Path | None:
+    """Persist the server's host/port so ``status`` can locate it later."""
+
+    path = _state_file_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"host": host, "port": int(port), "pid": os.getpid()}
+        path.write_text(json.dumps(payload))
+        logger.debug("Recorded API server state in %s", path)
+        return path
+    except OSError as exc:
+        logger.warning("Unable to record API server state in %s: %s", path, exc)
+        return None
+
+
+def _remove_state(path: Path | None, *, logger) -> None:
+    """Delete the persisted state file, ignoring if it is already gone."""
+
+    if path is None:
+        path = _state_file_path()
+    try:
+        path.unlink()
+        logger.debug("Removed API server state file %s", path)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Unable to remove API server state file %s: %s", path, exc)
+
+
+def _read_state(*, logger) -> tuple[str, int] | None:
+    """Return the stored ``(host, port)`` pair if available and valid."""
+
+    path = _state_file_path()
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.debug("Unable to read API server state from %s: %s", path, exc)
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("Ignoring corrupt API server state file %s: %s", path, exc)
+        return None
+
+    host = data.get("host")
+    port = data.get("port")
+    if not isinstance(host, str):
+        logger.warning("State file %s missing 'host'; treating API as stopped", path)
+        return None
+
+    try:
+        port_int = int(port)
+    except (TypeError, ValueError):
+        logger.warning("State file %s missing valid 'port'; treating API as stopped", path)
+        return None
+
+    return host, port_int
+
+
+def _probe_host(host: str) -> str:
+    """Return the hostname to probe for status checks."""
+
+    if host in {"0.0.0.0", "::"}:
+        return "127.0.0.1"
+    return host
+
+
+def _is_server_running(host: str, port: int, *, logger) -> bool:
+    """Return ``True`` if the FastAPI server responds to its status endpoint."""
+
+    probe_host = _probe_host(host)
+    url = f"http://{probe_host}:{port}{_STATUS_ENDPOINT}"
+    try:
+        response = requests.get(url, timeout=_REQUEST_TIMEOUT)
+    except requests.RequestException as exc:
+        logger.debug("Status probe failed for %s: %s", url, exc)
+        return False
+
+    if response.status_code != 200:
+        logger.debug(
+            "Status probe for %s returned unexpected status %s",
+            url,
+            response.status_code,
+        )
+        return False
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        logger.debug("Status probe for %s returned invalid JSON: %s", url, exc)
+        return False
+
+    return bool(payload.get("ok"))
 
 
 def register_subcommands(subparsers):
@@ -27,7 +150,7 @@ def register_subcommands(subparsers):
 
     """
 
-    _ = subparsers.add_parser("status", help="Check api status")
+    _ = subparsers.add_parser("status", help="Check whether the API is running")
     starter_parser = subparsers.add_parser("start", help="start the API server")
     starter_parser.add_argument(
         "--host", default="localhost", help="Host to run the API server "
@@ -61,13 +184,29 @@ def dispatch(args):
 
     logger = get_logger(__file__)
 
-    from ispec.api.main import app
-    import uvicorn
-
     if args.subcommand == "status":
-        logger.info("run ispec api start to start the API server")
-    elif args.subcommand == "start":
-        logger.info(f"Starting API server at {args.host}:{args.port}")
-        uvicorn.run(app, host=args.host, port=args.port)
-    else:
-        logger.error(f"No handler for subcommand: {args.subcommand}")
+        state = _read_state(logger=logger)
+        if state is None:
+            logger.info("API server is not running.")
+            return
+
+        host, port = state
+        if _is_server_running(host, port, logger=logger):
+            logger.info("API server is running at %s:%s", host, port)
+        else:
+            logger.info("API server is not running at %s:%s", host, port)
+        return
+
+    if args.subcommand == "start":
+        from ispec.api.main import app
+        import uvicorn
+
+        logger.info("Starting API server at %s:%s", args.host, args.port)
+        state_path = _write_state(args.host, args.port, logger=logger)
+        try:
+            uvicorn.run(app, host=args.host, port=args.port)
+        finally:
+            _remove_state(state_path, logger=logger)
+        return
+
+    logger.error(f"No handler for subcommand: {args.subcommand}")

--- a/tests/integration/test_cli_api.py
+++ b/tests/integration/test_cli_api.py
@@ -1,3 +1,5 @@
+import json
+import os
 import sys
 from pathlib import Path
 import types
@@ -6,14 +8,23 @@ import types
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
 
-def test_api_start_invokes_uvicorn_run(monkeypatch):
+def test_api_start_invokes_uvicorn_run(monkeypatch, tmp_path):
     captured = {}
+
+    state_file = tmp_path / "api_state.json"
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("ISPEC_API_STATE_FILE", str(state_file))
+    monkeypatch.setenv("ISPEC_LOG_DIR", str(log_dir))
 
     # Stub out the database CLI module to avoid heavy dependencies
     dummy_db = types.ModuleType("db")
     dummy_db.register_subcommands = lambda subparsers: None
     dummy_db.dispatch = lambda args: None
     monkeypatch.setitem(sys.modules, "ispec.cli.db", dummy_db)
+
+    dummy_ispec_db = types.ModuleType("ispec.db")
+    dummy_ispec_db.get_session = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "ispec.db", dummy_ispec_db)
 
     # Stub out the FastAPI application module
     dummy_api_main = types.ModuleType("ispec.api.main")
@@ -26,6 +37,9 @@ def test_api_start_invokes_uvicorn_run(monkeypatch):
     def fake_run(app, host, port, *args, **kwargs):
         captured["host"] = host
         captured["port"] = port
+        captured["state_exists"] = state_file.exists()
+        if state_file.exists():
+            captured["state_payload"] = json.loads(state_file.read_text())
 
     dummy_uvicorn.run = fake_run
     monkeypatch.setitem(sys.modules, "uvicorn", dummy_uvicorn)
@@ -42,3 +56,119 @@ def test_api_start_invokes_uvicorn_run(monkeypatch):
 
     assert captured["host"] == "127.0.0.1"
     assert captured["port"] == 9000
+    assert captured["state_exists"] is True
+    payload = captured["state_payload"]
+    assert payload["host"] == "127.0.0.1"
+    assert payload["port"] == 9000
+    assert payload["pid"] == os.getpid()
+    assert not state_file.exists()
+
+
+def test_api_status_reports_not_running_without_state(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("ISPEC_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("ISPEC_API_STATE_FILE", str(tmp_path / "missing.json"))
+
+    dummy_ispec_db = types.ModuleType("ispec.db")
+    dummy_ispec_db.get_session = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "ispec.db", dummy_ispec_db)
+
+    from ispec.cli import api as api_cli
+
+    called = {}
+
+    def fail_get(*args, **kwargs):
+        called["called"] = True
+        raise AssertionError("status should not probe without state")
+
+    monkeypatch.setattr(api_cli.requests, "get", fail_get)
+
+    logger = api_cli.get_logger(api_cli.__file__)
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level("INFO", logger=logger.name):
+            api_cli.dispatch(types.SimpleNamespace(subcommand="status"))
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    assert "API server is not running." in caplog.text
+    assert "called" not in called
+
+
+def test_api_status_reports_running(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("ISPEC_LOG_DIR", str(tmp_path / "logs"))
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("ISPEC_API_STATE_FILE", str(state_file))
+    state_file.write_text(json.dumps({"host": "localhost", "port": 9100}))
+
+    dummy_ispec_db = types.ModuleType("ispec.db")
+    dummy_ispec_db.get_session = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "ispec.db", dummy_ispec_db)
+
+    from ispec.cli import api as api_cli
+
+    class DummyResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"ok": True}
+
+    captured = {}
+
+    def fake_get(url, timeout):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(api_cli.requests, "get", fake_get)
+
+    logger = api_cli.get_logger(api_cli.__file__)
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level("INFO", logger=logger.name):
+            api_cli.dispatch(types.SimpleNamespace(subcommand="status"))
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    assert "API server is running at localhost:9100" in caplog.text
+    assert captured["url"] == "http://localhost:9100/status"
+    assert captured["timeout"] == api_cli._REQUEST_TIMEOUT
+
+
+def test_api_status_uses_loopback_for_wildcard_host(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("ISPEC_LOG_DIR", str(tmp_path / "logs"))
+    state_file = tmp_path / "wildcard.json"
+    monkeypatch.setenv("ISPEC_API_STATE_FILE", str(state_file))
+    state_file.write_text(json.dumps({"host": "0.0.0.0", "port": 9200}))
+
+    dummy_ispec_db = types.ModuleType("ispec.db")
+    dummy_ispec_db.get_session = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "ispec.db", dummy_ispec_db)
+
+    from ispec.cli import api as api_cli
+
+    class DummyResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"ok": True}
+
+    captured = {}
+
+    def fake_get(url, timeout):
+        captured["url"] = url
+        return DummyResponse()
+
+    monkeypatch.setattr(api_cli.requests, "get", fake_get)
+
+    logger = api_cli.get_logger(api_cli.__file__)
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level("INFO", logger=logger.name):
+            api_cli.dispatch(types.SimpleNamespace(subcommand="status"))
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    assert "API server is running at 0.0.0.0:9200" in caplog.text
+    assert captured["url"] == "http://127.0.0.1:9200/status"


### PR DESCRIPTION
## Summary
- persist API server host/port information so `ispec api status` can locate the running instance and probe its health endpoint
- update `ispec api start` to write and clean up the state file while logging clearer status messages
- extend the CLI integration tests to cover the new status behaviour, state persistence, and wildcard host probing

## Testing
- pytest tests/integration/test_cli_api.py
- pytest *(fails: missing optional dependencies such as fastapi, pandas, sqlalchemy, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c857548a6083328d00c22499311f4b