### PR TITLE
Add logging show-level command

### DIFF
--- a/src/ispec/cli/logging.py
+++ b/src/ispec/cli/logging.py
@@ -8,7 +8,7 @@ handlers.
 import logging
 
 from ispec.logging import get_logger, reset_logger
-from ispec.logging.logging import _resolve_log_file
+from ispec.logging.logging import _resolve_log_file, get_configured_level
 
 
 def register_subcommands(subparsers):
@@ -30,6 +30,9 @@ def register_subcommands(subparsers):
     )
 
     subparsers.add_parser("show-path", help="Show the log file location")
+    subparsers.add_parser(
+        "show-level", help="Show the configured logging level"
+    )
 
 
 def dispatch(args):
@@ -42,5 +45,8 @@ def dispatch(args):
     elif args.subcommand == "show-path":
         path = _resolve_log_file().resolve()
         print(path)
+    elif args.subcommand == "show-level":
+        level = get_configured_level()
+        print(level)
     else:
         get_logger(__file__).error("No handler for subcommand: %s", args.subcommand)

--- a/src/ispec/logging/logging.py
+++ b/src/ispec/logging/logging.py
@@ -107,3 +107,10 @@ def reset_logger(name=None):
     else:
         _LOGGER_INITIALIZED.pop(name, None)
 
+
+def get_configured_level(name="ispec"):
+    """Return the configured logging level name for ``name``."""
+
+    level = logging.getLogger(name).getEffectiveLevel()
+    return logging.getLevelName(level)
+

--- a/tests/unit/cli/test_logging_module.py
+++ b/tests/unit/cli/test_logging_module.py
@@ -20,6 +20,14 @@ def test_register_subcommands_parses_set_level():
     assert args.level == "DEBUG"
 
 
+def test_register_subcommands_parses_show_level():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    logging_cli.register_subcommands(subparsers)
+    args = parser.parse_args(["show-level"])
+    assert args.subcommand == "show-level"
+
+
 def test_dispatch_set_level_invokes_logging_helpers(monkeypatch):
     reset_mock = MagicMock()
     get_mock = MagicMock()
@@ -38,3 +46,10 @@ def test_dispatch_show_path_prints_resolved_path(monkeypatch, capsys):
     args = types.SimpleNamespace(subcommand="show-path")
     logging_cli.dispatch(args)
     assert capsys.readouterr().out.strip() == str(expected.resolve())
+
+
+def test_dispatch_show_level_prints_configured_level(monkeypatch, capsys):
+    monkeypatch.setattr(logging_cli, "get_configured_level", lambda: "WARNING")
+    args = types.SimpleNamespace(subcommand="show-level")
+    logging_cli.dispatch(args)
+    assert capsys.readouterr().out.strip() == "WARNING"


### PR DESCRIPTION
## Summary
- register the new `show-level` logging subcommand and dispatch it through the configuration helper
- expose a helper to obtain the effective logging level for reuse by the CLI
- extend the CLI unit tests to cover parsing and output of the `show-level` command

## Testing
- pytest tests/unit/cli/test_logging_module.py


------
https://chatgpt.com/codex/tasks/task_e_68c85c05e6cc8332a76192c6ae6913a2