### PR TITLE
Add module docstring and remove unused io helpers

### DIFF
--- a/src/ispec/io/io_file.py
+++ b/src/ispec/io/io_file.py
@@ -1,5 +1,6 @@
+"""High-level helpers for importing tabular data files into the iSPEC database."""
+
 # io/io_file.py
-import sqlite3
 from functools import partial
 
 import pandas as pd
@@ -102,28 +103,3 @@ def import_file(file_path, table_name, db_file_path=None, **kwargs):
 
     return
 
-
-"""
-def get_table_colu(db_file_path,table_name):
-    if tables.get(table_name) is not None:
-        with sqlite3.connect(db_file_path) as conn:
-            c = conn.cursor()
-            c.execute("SELECT * FROM " + table_name)
-            res = c.fetchall()
-        return res
-        
-        
-
-def clean_up_import(dict,db_file_path,table_name):
-    checkName = get_table_colu(db_file_path,table_name)
-    colsRemove = []
-    for bigKey in dict:
-        for key in bigKey:
-            if "RecNo" in key:
-                key = "id"
-            if key not in checkName and key != "id":
-                colsRemove.append(key)
-        for removable in colsRemove:
-            bigKey.pop(removable)
-    return dict   
-"""


### PR DESCRIPTION
## Summary
- add a descriptive module-level docstring for the import helpers module
- remove the dead, commented-out helper functions that were no longer used

## Testing
- pytest tests/integration/test_cli_db.py


------
https://chatgpt.com/codex/tasks/task_e_68c8ae718024833283343fcfd626c9dd