### PR TITLE
Add JSON support for CLI import and export

### DIFF
--- a/src/ispec/cli/db.py
+++ b/src/ispec/cli/db.py
@@ -35,8 +35,8 @@ def register_subcommands(subparsers):
 
     Exporting data::
 
-    >>> parser.parse_args(["export", "--table-name", "person", "--file", "out.csv"])
-    Namespace(subcommand='export', table_name='person', file='out.csv')
+    >>> parser.parse_args(["export", "--table-name", "person", "--file", "out.json"])
+    Namespace(subcommand='export', table_name='person', file='out.json')
 
     """
 
@@ -54,9 +54,9 @@ def register_subcommands(subparsers):
     )
     import_parser.add_argument("--file", required=True)
 
-    export_parser = subparsers.add_parser("export", help="Export table to CSV")
+    export_parser = subparsers.add_parser("export", help="Export table to CSV or JSON")
     export_parser.add_argument("--table-name", required=True, choices=("person", "project"))
-    export_parser.add_argument("--file", required=True, help="Output CSV file")
+    export_parser.add_argument("--file", required=True, help="Output file (CSV or JSON)")
 
 
 def dispatch(args):
@@ -81,7 +81,7 @@ def dispatch(args):
 
     Exporting data::
 
-        >>> args = types.SimpleNamespace(subcommand="export", table_name="person", file="out.csv")
+        >>> args = types.SimpleNamespace(subcommand="export", table_name="person", file="out.json")
         >>> dispatch(args)  # doctest: +SKIP
 
     """

--- a/src/ispec/db/operations.py
+++ b/src/ispec/db/operations.py
@@ -6,6 +6,7 @@ import pandas as pd
 from ispec.db.init import initialize_db
 from ispec.db.connect import get_session
 from ispec.logging import get_logger
+from ispec.io.io_file import get_writer
 
 
 logger = get_logger(__file__)
@@ -80,18 +81,20 @@ def initialize(file_path=None):
 
 
 def export_table(table_name: str, file_path: str) -> None:
-    """Export a database table to a CSV file.
+    """Export a database table to a file.
 
     Parameters
     ----------
     table_name:
         Name of the table to export.
     file_path:
-        Destination path for the CSV file.
+        Destination path for the exported file. Supported extensions include
+        ``.csv`` and ``.json``.
     """
 
     logger.info("exporting table %s to %s", table_name, file_path)
     with get_session() as session:
         df = pd.read_sql_table(table_name, session.bind)
-    df.to_csv(file_path, index=False)
+    writer = get_writer(file_path)
+    writer(df)
 

--- a/src/ispec/io/io_file.py
+++ b/src/ispec/io/io_file.py
@@ -1,6 +1,7 @@
 # io/io_file.py
 import sqlite3
 from functools import partial
+from collections.abc import Callable
 
 import pandas as pd
 import numpy as np
@@ -30,11 +31,34 @@ def get_reader(file: str, **kwargs):
         return partial(pd.read_table, **kwargs)
     elif file.endswith(".csv"):
         return partial(pd.read_csv, **kwargs)
+    elif file.endswith(".json"):
+        return partial(pd.read_json, **kwargs)
     elif file.endswith(".xlsx"):
         return partial(pd.read_excel, **kwargs)
 
     else:
         raise ValueError(f"Unsupported file extension: {file}")
+
+
+def get_writer(file: str, **kwargs) -> Callable[[pd.DataFrame], None]:
+    """Return a callable that exports a DataFrame based on ``file`` extension."""
+
+    if file.endswith(".csv"):
+        def write_csv(df: pd.DataFrame) -> None:
+            csv_kwargs = {"index": False}
+            csv_kwargs.update(kwargs)
+            df.to_csv(file, **csv_kwargs)
+
+        return write_csv
+    elif file.endswith(".json"):
+        def write_json(df: pd.DataFrame) -> None:
+            json_kwargs = {"orient": "records"}
+            json_kwargs.update(kwargs)
+            df.to_json(file, **json_kwargs)
+
+        return write_json
+
+    raise ValueError(f"Unsupported file extension: {file}")
 
 
 def connect_project_person(db_file_path):

--- a/tests/integration/test_cli_db.py
+++ b/tests/integration/test_cli_db.py
@@ -81,6 +81,51 @@ def test_cli_import_inserts_data(tmp_path, monkeypatch):
     assert rows == [("Alice", "Smith")]
 
 
+def test_cli_import_json_inserts_data(tmp_path, monkeypatch):
+    """JSON input files should be imported via the CLI."""
+
+    db_file = tmp_path / "test.db"
+
+    monkeypatch.setattr(sys, "argv", ["ispec", "db", "init", "--file", str(db_file)])
+    main()
+    assert db_file.exists()
+
+    json_file = tmp_path / "people.json"
+    pd.DataFrame(
+        [
+            {
+                "id": 2,
+                "ppl_AddedBy": "tester",
+                "ppl_Name_First": "Bob",
+                "ppl_Name_Last": "Jones",
+            }
+        ]
+    ).to_json(json_file, orient="records")
+
+    monkeypatch.setenv("ISPEC_DB_PATH", str(db_file))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ispec",
+            "db",
+            "import",
+            "--table-name",
+            "person",
+            "--file",
+            str(json_file),
+        ],
+    )
+    main()
+
+    with sqlite3.connect(db_file) as conn:
+        rows = conn.execute(
+            "SELECT ppl_Name_First, ppl_Name_Last FROM person WHERE id = 2"
+        ).fetchall()
+
+    assert rows == [("Bob", "Jones")]
+
+
 def test_cli_export_writes_csv(tmp_path, monkeypatch):
     """Exporting data via the CLI should create a CSV file with table rows."""
 
@@ -139,6 +184,63 @@ def test_cli_export_writes_csv(tmp_path, monkeypatch):
 
     df = pd.read_csv(export_file)
     assert df.iloc[0]["ppl_Name_First"] == "Alice"
+
+
+def test_cli_export_writes_json(tmp_path, monkeypatch):
+    """Exporting data via the CLI should support JSON output."""
+
+    db_file = tmp_path / "test.db"
+
+    monkeypatch.setattr(sys, "argv", ["ispec", "db", "init", "--file", str(db_file)])
+    main()
+    assert db_file.exists()
+
+    csv_file = tmp_path / "people.csv"
+    pd.DataFrame(
+        [
+            {
+                "id": 3,
+                "ppl_AddedBy": "tester",
+                "ppl_Name_First": "Carol",
+                "ppl_Name_Last": "Brown",
+            }
+        ]
+    ).to_csv(csv_file, index=False)
+
+    monkeypatch.setenv("ISPEC_DB_PATH", str(db_file))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ispec",
+            "db",
+            "import",
+            "--table-name",
+            "person",
+            "--file",
+            str(csv_file),
+        ],
+    )
+    main()
+
+    export_file = tmp_path / "export.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ispec",
+            "db",
+            "export",
+            "--table-name",
+            "person",
+            "--file",
+            str(export_file),
+        ],
+    )
+    main()
+
+    df = pd.read_json(export_file)
+    assert "Carol" in df["ppl_Name_First"].values
 
 
 def test_db_status_prints_sqlite_version(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- extend the import utilities to read JSON files and add a writer helper for JSON exports
- update the CLI export messaging and database operations to use the new writer helper
- add integration coverage for JSON import and export via the CLI

## Testing
- pytest tests/integration/test_cli_db.py

------
https://chatgpt.com/codex/tasks/task_e_68c8aeb0327083328bef7eda61cd18ad