### PR TITLE
Add CLI show-level logging command documentation and integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,13 @@ Control logging output without editing code:
 ```bash
 ispec logging set-level INFO
 ispec logging show-path
+ispec logging show-level
 ```
 
 The logging CLI persists the selected level to a JSON config alongside the
-logs, resets handlers when you change levels, and reports the active log file
-path resolved by the logging utility module.【F:src/ispec/cli/logging.py†L11-L55】【F:src/ispec/logging/config.py†L1-L90】【F:src/ispec/logging/logging.py†L1-L88】
+logs, resets handlers when you change levels, reports the active log file
+path resolved by the logging utility module, and prints the configured log
+level for quick inspection.【F:src/ispec/cli/logging.py†L11-L55】【F:src/ispec/logging/config.py†L1-L90】【F:src/ispec/logging/logging.py†L1-L88】
 
 ## API service
 

--- a/src/ispec/cli/logging.py
+++ b/src/ispec/cli/logging.py
@@ -8,7 +8,7 @@ handlers.
 import logging
 
 from ispec.logging import get_logger, reset_logger
-from ispec.logging.logging import _resolve_log_file, get_configured_level, _resolve_log_file
+from ispec.logging.logging import get_configured_level, _resolve_log_file
 from ispec.logging.config import save_log_level
 
 
@@ -50,7 +50,6 @@ def dispatch(args):
         path = _resolve_log_file().resolve()
         print(path)
     elif args.subcommand == "show-level":
-        level = get_configured_level()
-        print(level)
+        print(get_configured_level())
     else:
         get_logger(__file__).error("No handler for subcommand: %s", args.subcommand)

--- a/tests/integration/test_cli_logging.py
+++ b/tests/integration/test_cli_logging.py
@@ -1,0 +1,51 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure the src directory is on the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+
+def test_logging_show_level_reports_configured_level(tmp_path, monkeypatch, capsys):
+    """`ispec logging show-level` should print the configured log level."""
+
+    config_file = tmp_path / "config" / "logging.json"
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("ISPEC_LOG_CONFIG", str(config_file))
+    monkeypatch.setenv("ISPEC_LOG_DIR", str(log_dir))
+
+    dummy_ispec_db = types.ModuleType("ispec.db")
+    dummy_ispec_db.get_session = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "ispec.db", dummy_ispec_db)
+
+    from ispec.logging import reset_logger
+
+    reset_logger()
+
+    dummy_cli_db = types.ModuleType("ispec.cli.db")
+    dummy_cli_db.register_subcommands = lambda subparsers: None
+    dummy_cli_db.dispatch = lambda args: None
+    monkeypatch.setitem(sys.modules, "ispec.cli.db", dummy_cli_db)
+
+    dummy_cli_api = types.ModuleType("ispec.cli.api")
+    dummy_cli_api.register_subcommands = lambda subparsers: None
+    dummy_cli_api.dispatch = lambda args: None
+    monkeypatch.setitem(sys.modules, "ispec.cli.api", dummy_cli_api)
+
+    from ispec.cli.main import main
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ispec", "logging", "set-level", "DEBUG"],
+    )
+    main()
+    capsys.readouterr()
+
+    monkeypatch.setattr(sys, "argv", ["ispec", "logging", "show-level"])
+    main()
+    captured = capsys.readouterr()
+
+    assert captured.out.strip() == "DEBUG"
+
+    reset_logger()


### PR DESCRIPTION
## Summary
- ensure the `ispec logging show-level` subcommand prints the configured log level
- document the new `show-level` command alongside other logging instructions
- add an integration test that covers `show-level` output

## Testing
- pytest tests/integration/test_cli_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68c8af537f108332af29f6cc5f0c5307