### PR TITLE
Add Alembic migrations and CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ can manage people, projects, and supporting documents from one place.
   - [Database location](#database-location)
 - [Command line interface](#command-line-interface)
   - [Database commands](#database-commands)
+  - [Database migrations](#database-migrations)
   - [API commands](#api-commands)
   - [Logging commands](#logging-commands)
 - [API service](#api-service)
@@ -142,6 +143,26 @@ ispec db export --table-name project --file project.csv
 These commands delegate to the CRUD layer and IO helpers that batch insert
 rows, update relationship tables, and log progress.【F:src/ispec/cli/db.py†L11-L78】【F:tests/integration/test_cli_db.py†L27-L128】【F:src/ispec/io/io_file.py†L1-L82】
 
+### Database migrations
+
+Alembic migrations live in the top-level ``alembic`` directory. The migration
+environment imports the SQLAlchemy metadata from ``ispec.db.models`` so
+autogeneration and revision scripts stay in sync with the ORM definitions.【F:alembic/env.py†L1-L66】
+An initial revision provisions all tables defined by the models by calling
+``Base.metadata.create_all`` inside Alembic's ``upgrade`` hook.【F:alembic/versions/0001_initial.py†L1-L26】
+
+Run migrations through the CLI:
+
+```bash
+ispec db upgrade            # apply all migrations to the head revision
+ispec db downgrade -1       # roll back the most recent revision
+ispec db upgrade head --database ./custom.db
+```
+
+The CLI builds an Alembic configuration at runtime, resolves the project root,
+and forwards the ``--database`` option so you can target specific SQLite files
+or URLs when applying migrations.【F:src/ispec/cli/db.py†L36-L148】
+
 ### API commands
 
 Start the FastAPI server with custom host/port options or check its status:
@@ -208,6 +229,8 @@ pytest
 
 Tests cover CLI flows, API endpoints, and IO utilities to ensure the core
 workflows behave as expected.【F:tests/integration/test_cli_db.py†L1-L129】【F:tests/integration/test_api_endpoints.py†L1-L121】
+Alembic migrations are validated by executing ``alembic upgrade head`` against a
+temporary database as part of the unit test suite.【F:tests/unit/db/test_migrations.py†L1-L39】
 
 ## Documentation utilities
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./ispec.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,5 @@
+This directory contains Alembic configuration for managing database migrations.
+
+The ``env.py`` module pulls SQLAlchemy metadata from ``ispec.db.models`` so
+revisions can autogenerate schema changes, and ``versions/`` stores individual
+migration scripts.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,112 @@
+"""Alembic environment configuration for iSPEC."""
+
+import os
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection, Engine
+
+from ispec.db.connect import get_db_path
+from ispec.db.models import Base
+
+# this is the Alembic Config object, which provides access to the values
+# within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name and Path(config.config_file_name).exists():
+    fileConfig(config.config_file_name)
+
+# target_metadata is used for 'autogenerate' support.
+target_metadata = Base.metadata
+
+
+def _coerce_sqlite_url(raw: str) -> str:
+    """Ensure a SQLite URL has the proper prefix."""
+
+    if raw.startswith("sqlite"):
+        return raw
+    return "sqlite:///" + raw
+
+
+def _get_database_url() -> str:
+    """Resolve the database URL for Alembic to use."""
+
+    env_url = os.getenv("ISPEC_DB_PATH")
+    if env_url:
+        return _coerce_sqlite_url(env_url)
+
+    configured_url = config.get_main_option("sqlalchemy.url")
+    if configured_url:
+        return configured_url
+
+    return get_db_path()
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = _get_database_url()
+    config.set_main_option("sqlalchemy.url", url)
+
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+        render_as_batch=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def _run_with_connection(connection: Connection) -> None:
+    """Configure Alembic to run migrations using ``connection``."""
+
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        render_as_batch=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    existing = config.attributes.get("connection")
+
+    if isinstance(existing, Engine):
+        with existing.connect() as connection:
+            _run_with_connection(connection)
+        return
+
+    if isinstance(existing, Connection):
+        _run_with_connection(existing)
+        return
+
+    url = _get_database_url()
+    config.set_main_option("sqlalchemy.url", url)
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        future=True,
+    )
+
+    with connectable.connect() as connection:
+        _run_with_connection(connection)
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,19 @@
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    pass
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    pass

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,30 @@
+"""Create initial iSPEC tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+
+# revision identifiers, used by Alembic.
+revision = "0001_initial"
+down_revision = None
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Apply the initial schema using the SQLAlchemy models."""
+
+    from ispec.db.models import Base
+
+    bind = op.get_bind()
+    Base.metadata.create_all(bind=bind)
+
+
+def downgrade() -> None:
+    """Drop the schema created by :func:`upgrade`."""
+
+    from ispec.db.models import Base
+
+    bind = op.get_bind()
+    Base.metadata.drop_all(bind=bind)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A Python package for database"
 authors = [{ name = "Your Name", email = "alexander.saltzman@bcm.edu" }]
 license = { file = "LICENSE" }
 readme = "README.md"
-dependencies = ["requests", "uvicorn", "rich"]
+dependencies = ["requests", "uvicorn", "rich", "alembic"]
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
@@ -22,6 +22,7 @@ test = [
     "fastapi",
     "httpx",
     "faker",
+    "alembic",
 ]
 
 [project.scripts]

--- a/src/ispec/cli/db.py
+++ b/src/ispec/cli/db.py
@@ -6,8 +6,11 @@ database operations.
 """
 
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
+from alembic import command
+from alembic.config import Config
 from rich.console import Console
 from rich.table import Table
 
@@ -58,6 +61,36 @@ def register_subcommands(subparsers):
     export_parser.add_argument("--table-name", required=True, choices=("person", "project"))
     export_parser.add_argument("--file", required=True, help="Output CSV file")
 
+    upgrade_parser = subparsers.add_parser(
+        "upgrade", help="Apply Alembic migrations up to a revision"
+    )
+    upgrade_parser.add_argument(
+        "revision",
+        nargs="?",
+        default="head",
+        help="Alembic revision identifier to upgrade to (default: head)",
+    )
+    upgrade_parser.add_argument(
+        "--database",
+        dest="database",
+        help="Database URL or filesystem path to migrate",
+    )
+
+    downgrade_parser = subparsers.add_parser(
+        "downgrade", help="Revert Alembic migrations"
+    )
+    downgrade_parser.add_argument(
+        "revision",
+        nargs="?",
+        default="-1",
+        help="Alembic revision identifier to downgrade to (default: -1)",
+    )
+    downgrade_parser.add_argument(
+        "--database",
+        dest="database",
+        help="Database URL or filesystem path to migrate",
+    )
+
 
 def dispatch(args):
     """Run the database operation associated with ``args.subcommand``.
@@ -99,6 +132,10 @@ def dispatch(args):
         operations.export_table(args.table_name, args.file)
     elif args.subcommand == "init":
         operations.initialize(file_path=args.file)
+    elif args.subcommand == "upgrade":
+        _run_alembic_command("upgrade", args.revision, database=args.database)
+    elif args.subcommand == "downgrade":
+        _run_alembic_command("downgrade", args.revision, database=args.database)
     else:
         logger.info("no dispatched function provided for %s", args.subcommand)
 
@@ -144,3 +181,66 @@ def _render_table_overview(
             table.add_section()
 
     console.print(table)
+
+
+def _run_alembic_command(action: str, revision: str, database: str | None) -> None:
+    """Execute an Alembic migration command."""
+
+    logger = get_logger(__file__)
+    config = _build_alembic_config(database)
+    logger.info("running alembic %s to %s", action, revision)
+
+    if action == "upgrade":
+        command.upgrade(config, revision)
+    elif action == "downgrade":
+        command.downgrade(config, revision)
+    else:  # pragma: no cover - guarded by call sites
+        raise ValueError(f"Unsupported Alembic action: {action}")
+
+
+def _build_alembic_config(database: str | None) -> Config:
+    """Create an Alembic :class:`~alembic.config.Config` instance."""
+
+    project_root = _find_project_root()
+    config_path = project_root / "alembic.ini"
+
+    alembic_config = Config(str(config_path)) if config_path.exists() else Config()
+    alembic_config.set_main_option("script_location", str(project_root / "alembic"))
+
+    normalized = _normalize_database_option(database)
+    if normalized:
+        alembic_config.set_main_option("sqlalchemy.url", normalized)
+    elif not alembic_config.get_main_option("sqlalchemy.url"):
+        # Provide an empty value so env.py falls back to get_db_path().
+        alembic_config.set_main_option("sqlalchemy.url", "")
+
+    return alembic_config
+
+
+def _find_project_root() -> Path:
+    """Locate the repository root that contains the Alembic directory."""
+
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "alembic").is_dir():
+            return parent
+    raise FileNotFoundError("Could not locate the Alembic directory.")
+
+
+def _normalize_database_option(database: str | None) -> str | None:
+    """Normalize a database argument into an Alembic-friendly URL."""
+
+    if not database:
+        return None
+
+    database = database.strip()
+    if not database:
+        return None
+
+    if "://" in database:
+        return database
+
+    expanded = str(Path(database).expanduser())
+    if expanded.startswith("sqlite"):
+        return expanded
+
+    return f"sqlite:///{expanded}"

--- a/src/ispec/db/operations.py
+++ b/src/ispec/db/operations.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from sqlalchemy import inspect, text
@@ -8,17 +9,24 @@ from ispec.db.connect import get_session
 from ispec.logging import get_logger
 
 
-logger = get_logger(__file__)
+logger = get_logger(__file__, propagate=True)
+
+
+def _log_info(message: str, *args: Any) -> None:
+    """Log ``message`` using both the module logger and the root logger."""
+
+    logger.info(message, *args)
+    logging.getLogger().info(message, *args)
 
 
 def check_status():
     """Query the database for its SQLite version and log/return it."""
-    logger.info("checking db status...")
+    _log_info("checking db status...")
     with get_session() as session:
         result = session.execute(text("SELECT sqlite_version();")).fetchone()
         if result:
             version = result[0]
-            logger.info("sqlite version: %s", version)
+            _log_info("sqlite version: %s", version)
             return version
         logger.warning("sqlite version query returned no result")
         return None
@@ -41,11 +49,11 @@ def show_tables(file_path: str | None = None) -> dict[str, list[dict[str, Any]]]
         keys.
     """
 
-    logger.info("showing tables..")
+    _log_info("showing tables..")
     with get_session(file_path=file_path) as session:
         inspector = inspect(session.bind)
         table_names = sorted(inspector.get_table_names())
-        logger.info("tables: %s", table_names)
+        _log_info("tables: %s", table_names)
 
         table_definitions: dict[str, list[dict[str, Any]]] = {}
         for table_name in table_names:

--- a/tests/unit/db/test_migrations.py
+++ b/tests/unit/db/test_migrations.py
@@ -1,0 +1,159 @@
+"""Tests that exercise Alembic migrations end-to-end."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.pool import StaticPool
+
+from ispec.db.models import Base
+
+REPO_ROOT_SENTINEL = "alembic.ini"
+
+
+def _project_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / REPO_ROOT_SENTINEL).exists():
+            return parent
+    msg = "Unable to locate project root with alembic.ini"
+    raise RuntimeError(msg)
+
+
+def _make_config(project_root: Path) -> Config:
+    config = Config(str(project_root / REPO_ROOT_SENTINEL))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+    return config
+
+
+@contextmanager
+def _engine_connection():
+    """Provide a shared in-memory SQLite engine and transaction."""
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    try:
+        with engine.begin() as conn:
+            conn.exec_driver_sql("PRAGMA foreign_keys=ON;")
+        with engine.begin() as conn:
+            yield engine, conn
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def alembic_cfg() -> Config:
+    return _make_config(_project_root())
+
+
+@pytest.fixture(scope="function")
+def live_conn(alembic_cfg: Config):
+    with _engine_connection() as (engine, conn):
+        alembic_cfg.attributes["connection"] = conn
+        yield engine, conn
+
+
+def _script_dir(cfg: Config) -> ScriptDirectory:
+    return ScriptDirectory.from_config(cfg)
+
+
+def test_single_head(alembic_cfg: Config) -> None:
+    script = _script_dir(alembic_cfg)
+    heads = script.get_heads()
+    assert len(heads) == 1, f"Multiple heads found: {heads}"
+    assert script.get_current_head() == heads[0]
+
+
+def test_upgrade_head_creates_core_tables(alembic_cfg: Config, live_conn) -> None:
+    engine, _ = live_conn
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(engine)
+    tables = set(inspector.get_table_names())
+    expected = {
+        "person",
+        "project",
+        "project_comment",
+        "project_person",
+        "letter_of_support",
+    }
+
+    assert expected.issubset(tables)
+
+
+def test_model_metadata_matches_database(alembic_cfg: Config, live_conn) -> None:
+    engine, _ = live_conn
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(engine)
+    db_tables = set(inspector.get_table_names())
+    model_tables = {table.name for table in Base.metadata.sorted_tables}
+
+    assert model_tables.issubset(db_tables)
+
+
+def test_upgrade_is_idempotent(alembic_cfg: Config, live_conn) -> None:
+    command.upgrade(alembic_cfg, "head")
+    command.upgrade(alembic_cfg, "head")
+
+
+def test_roundtrip_each_revision(alembic_cfg: Config, live_conn) -> None:
+    engine, _ = live_conn
+    script = _script_dir(alembic_cfg)
+    revisions = list(script.walk_revisions(base="base", head="heads"))[::-1]
+
+    for revision in revisions:
+        command.upgrade(alembic_cfg, revision.revision)
+        inspect(engine).get_table_names()
+
+    for down_revision in (rev.down_revision for rev in revisions[::-1]):
+        target = down_revision or "base"
+        command.downgrade(alembic_cfg, target)
+
+
+def test_fk_enforcement_present(alembic_cfg: Config, live_conn) -> None:
+    _, conn = live_conn
+    command.upgrade(alembic_cfg, "head")
+
+    with pytest.raises(IntegrityError):
+        conn.execute(
+            text(
+                """
+                INSERT INTO project_comment (id, project_id, person_id, com_Comment)
+                VALUES (1, 9999, 9999, 'fk test')
+                """
+            )
+        )
+
+
+def test_foreign_key_metadata(alembic_cfg: Config, live_conn) -> None:
+    engine, _ = live_conn
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(engine)
+
+    comment_fks = {
+        fk["constrained_columns"][0]: fk["referred_table"]
+        for fk in inspector.get_foreign_keys("project_comment")
+    }
+    assert comment_fks == {"project_id": "project", "person_id": "person"}
+
+    mapping_fks = {
+        fk["constrained_columns"][0]: fk["referred_table"]
+        for fk in inspector.get_foreign_keys("project_person")
+    }
+    assert mapping_fks == {"project_id": "project", "person_id": "person"}
+
+    for table in ("person", "project", "project_comment", "project_person"):
+        pk = inspector.get_pk_constraint(table)
+        assert pk["constrained_columns"] == ["id"], f"Missing PK for {table}"


### PR DESCRIPTION
## Summary
- add Alembic dependency and configuration files with an initial revision driven by the SQLAlchemy models
- expose `ispec db upgrade/downgrade` commands and document migration usage in the README
- run Alembic upgrades during tests and tweak logging to keep status output visible
- ensure the Alembic environment honors pre-supplied connections and expand the migration test suite with transactional coverage, revision round-trips, and foreign-key checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8af4ab834833291c5b3ed0a724a8b