### PR TITLE
Refactor assistant JSON parsing and reduce turn-decision prompt coupling

### DIFF
--- a/src/ispec/assistant/comment_intent.py
+++ b/src/ispec/assistant/comment_intent.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Callable
 from typing import Any
 
+from ispec.assistant.json_utils import parse_json_object
 from ispec.assistant.service import AssistantReply
 from ispec.prompt import load_bound_prompt, prompt_binding, prompt_observability_context
 
@@ -27,29 +28,6 @@ def project_comment_intent_schema() -> dict[str, Any]:
 @prompt_binding("assistant.comment_intent.classifier")
 def _project_comment_intent_prompt() -> str:
     return load_bound_prompt(_project_comment_intent_prompt).text
-
-
-def _parse_json_object(text: str | None) -> dict[str, Any] | None:
-    if not text:
-        return None
-    raw = str(text).strip()
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-        return parsed if isinstance(parsed, dict) else None
-    except Exception:
-        pass
-
-    start = raw.find("{")
-    end = raw.rfind("}")
-    if start < 0 or end <= start:
-        return None
-    try:
-        parsed = json.loads(raw[start : end + 1])
-        return parsed if isinstance(parsed, dict) else None
-    except Exception:
-        return None
 
 
 def _validate_intent_decision(decision: dict[str, Any]) -> dict[str, Any] | None:
@@ -106,6 +84,6 @@ def decide_project_comment_intent_vllm(
             extra={"surface": "support_chat", "stage": "project_comment_intent"},
         ),
     )
-    parsed = _parse_json_object(reply.content)
+    parsed = parse_json_object(reply.content)
     validated = _validate_intent_decision(parsed) if isinstance(parsed, dict) else None
     return validated, reply

--- a/src/ispec/assistant/json_utils.py
+++ b/src/ispec/assistant/json_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_json_object(text: str | None) -> dict[str, Any] | None:
+    """Parse a JSON object from plain text or a brace-delimited substring."""
+    if not text:
+        return None
+    raw = str(text).strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else None
+    except Exception:
+        pass
+
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        parsed = json.loads(raw[start : end + 1])
+        return parsed if isinstance(parsed, dict) else None
+    except Exception:
+        return None

--- a/src/ispec/assistant/tool_routing.py
+++ b/src/ispec/assistant/tool_routing.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from typing import Any
 
+from ispec.assistant.json_utils import parse_json_object
 from ispec.assistant.service import AssistantReply
 from ispec.prompt import load_bound_prompt, prompt_binding, prompt_observability_context
 
@@ -182,29 +183,6 @@ def _tool_router_system_prompt(groups: list[ToolGroup]) -> str:
     ).text
 
 
-def _parse_json_object(text: str | None) -> dict[str, Any] | None:
-    if not text:
-        return None
-    raw = str(text).strip()
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-        return parsed if isinstance(parsed, dict) else None
-    except Exception:
-        pass
-
-    start = raw.find("{")
-    end = raw.rfind("}")
-    if start < 0 or end <= start:
-        return None
-    try:
-        parsed = json.loads(raw[start : end + 1])
-        return parsed if isinstance(parsed, dict) else None
-    except Exception:
-        return None
-
-
 def _validate_router_decision(decision: dict[str, Any], *, group_names: set[str]) -> dict[str, Any] | None:
     primary = decision.get("primary")
     secondary: Any = decision.get("secondary")
@@ -288,7 +266,7 @@ def route_tool_groups_vllm(
             extra={"surface": "support_chat", "stage": "tool_router"},
         ),
     )
-    parsed = _parse_json_object(reply.content)
+    parsed = parse_json_object(reply.content)
     validated = (
         _validate_router_decision(parsed, group_names=set(group_names)) if isinstance(parsed, dict) else None
     )

--- a/src/ispec/assistant/turn_decision.py
+++ b/src/ispec/assistant/turn_decision.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal
 
 from ispec.assistant.classifier_service import generate_classifier_reply
+from ispec.assistant.json_utils import parse_json_object
 from ispec.assistant.response_contracts import ResponseContractName, response_contract_names
 from ispec.assistant.service import AssistantReply
 from ispec.assistant.tool_routing import ToolGroup, tool_names_for_groups
@@ -291,61 +292,43 @@ def _turn_decision_prompt(
     response_modes: list[ResponseMode],
     contract_caps: list[ResponseContractName],
 ) -> str:
-    scheduled_rules_block = ""
-    if source == "scheduled_assistant":
-        scheduled_rules_block = (
+    values = _turn_decision_prompt_values(
+        source=source,
+        groups=groups,
+        response_modes=response_modes,
+        contract_caps=contract_caps,
+    )
+    return load_bound_prompt(
+        _turn_decision_prompt,
+        values=values,
+    ).text
+
+
+def _turn_decision_prompt_values(
+    *,
+    source: TurnDecisionSource,
+    groups: list[ToolGroup],
+    response_modes: list[ResponseMode],
+    contract_caps: list[ResponseContractName],
+) -> dict[str, str]:
+    return {
+        "scheduled_rules_block": (
             "\n\nScheduled-assistant rules:\n"
             "- This is not an end-user conversation.\n"
             "- needs_clarification must be false.\n"
             "- clarification_reason must be none.\n"
             "- response_plan.mode must be single."
-        )
-
-    groups_block = ""
-    if groups:
-        groups_block = "\n\nAvailable tool groups:\n" + "\n".join(
-            f"- {group.name}: {group.description}" for group in groups
-        )
-
-    response_modes_block = ""
-    if response_modes:
-        response_modes_block = "\n\nAllowed response modes: " + ", ".join(response_modes)
-
-    contract_caps_block = ""
-    if contract_caps:
-        contract_caps_block = "\nAllowed response contract caps: " + ", ".join(contract_caps)
-
-    return load_bound_prompt(
-        _turn_decision_prompt,
-        values={
-            "scheduled_rules_block": scheduled_rules_block,
-            "groups_block": groups_block,
-            "response_modes_block": response_modes_block,
-            "contract_caps_block": contract_caps_block,
-        },
-    ).text
-
-def _parse_json_object(text: str | None) -> dict[str, Any] | None:
-    if not text:
-        return None
-    raw = str(text).strip()
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-        return parsed if isinstance(parsed, dict) else None
-    except Exception:
-        pass
-
-    start = raw.find("{")
-    end = raw.rfind("}")
-    if start < 0 or end <= start:
-        return None
-    try:
-        parsed = json.loads(raw[start : end + 1])
-        return parsed if isinstance(parsed, dict) else None
-    except Exception:
-        return None
+            if source == "scheduled_assistant"
+            else ""
+        ),
+        "groups_block": (
+            "\n\nAvailable tool groups:\n" + "\n".join(f"- {group.name}: {group.description}" for group in groups)
+            if groups
+            else ""
+        ),
+        "response_modes_block": ("\n\nAllowed response modes: " + ", ".join(response_modes)) if response_modes else "",
+        "contract_caps_block": ("\nAllowed response contract caps: " + ", ".join(contract_caps)) if contract_caps else "",
+    }
 
 
 def _clamp_confidence(raw: Any) -> float:
@@ -602,24 +585,12 @@ def run_turn_decision_pipeline(
     )
     prompt = load_bound_prompt(
         _turn_decision_prompt,
-        values={
-            "scheduled_rules_block": (
-                "\n\nScheduled-assistant rules:\n"
-                "- This is not an end-user conversation.\n"
-                "- needs_clarification must be false.\n"
-                "- clarification_reason must be none.\n"
-                "- response_plan.mode must be single."
-                if source == "scheduled_assistant"
-                else ""
-            ),
-            "groups_block": (
-                "\n\nAvailable tool groups:\n" + "\n".join(f"- {group.name}: {group.description}" for group in groups)
-                if groups
-                else ""
-            ),
-            "response_modes_block": ("\n\nAllowed response modes: " + ", ".join(response_modes)) if response_modes else "",
-            "contract_caps_block": ("\nAllowed response contract caps: " + ", ".join(contract_cap_names)) if contract_cap_names else "",
-        },
+        values=_turn_decision_prompt_values(
+            source=source,
+            groups=groups,
+            response_modes=response_modes,
+            contract_caps=contract_cap_names,
+        ),
     )
     messages = [
         {"role": "system", "content": prompt.text},
@@ -674,7 +645,7 @@ def run_turn_decision_pipeline(
             "meta": reply.meta,
         },
     )
-    parsed = _parse_json_object(reply.content)
+    parsed = parse_json_object(reply.content)
     result.raw_decision = parsed
     if not isinstance(parsed, dict):
         result.errors.append("invalid_json")

--- a/tests/unit/assistant/test_json_utils.py
+++ b/tests/unit/assistant/test_json_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from ispec.assistant.json_utils import parse_json_object
+
+
+def test_parse_json_object_accepts_plain_object() -> None:
+    assert parse_json_object('{"key":"value"}') == {"key": "value"}
+
+
+def test_parse_json_object_extracts_object_from_wrapped_text() -> None:
+    assert parse_json_object('Result: {"intent":"save_now","confidence":0.9}') == {
+        "intent": "save_now",
+        "confidence": 0.9,
+    }
+
+
+def test_parse_json_object_rejects_non_object_json() -> None:
+    assert parse_json_object('["not","an","object"]') is None
+
+
+def test_parse_json_object_returns_none_for_empty_or_invalid() -> None:
+    assert parse_json_object("") is None
+    assert parse_json_object("no-json-here") is None


### PR DESCRIPTION
### Motivation
- Multiple assistant classifier modules duplicated the same JSON-object parsing fallback logic, increasing maintenance cost and risk of inconsistent fixes. 
- The turn-decision prompt construction had duplicated block assembly in two call paths, creating hidden coupling that could drift.
- The shared parser had no focused unit tests, leaving a testing blind spot for basic JSON extraction behavior.

### Description
- Extracted the shared JSON-object parsing helper into `src/ispec/assistant/json_utils.py` as `parse_json_object` and replaced local `_parse_json_object` implementations in `comment_intent`, `tool_routing`, and `turn_decision` to use it.
- Introduced `_turn_decision_prompt_values(...)` in `src/ispec/assistant/turn_decision.py` and wired both prompt construction paths to reuse it, centralizing prompt-block assembly.
- Added unit tests for the parser in `tests/unit/assistant/test_json_utils.py` covering plain object parsing, extraction from wrapped text, non-object rejection, and invalid/empty inputs.
- Updated imports and usages in `src/ispec/assistant/comment_intent.py`, `src/ispec/assistant/tool_routing.py`, and `src/ispec/assistant/turn_decision.py` accordingly.

### Testing
- Ran focused unit tests with `python -m pytest -q -c /dev/null tests/unit/assistant/test_json_utils.py tests/unit/assistant/test_turn_decision.py` which completed successfully (`7 passed`).
- Note: a broader `pytest` invocation failed early in this environment due to a local `pytest.toml` parsing issue, so only the scoped tests above were executed here and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c69ddf70833297a4f9c7bc904e33)